### PR TITLE
Add example of global additionalProperties: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ to build REST services.
 * Optimized performance.
 * Embedded [Swagger UI](https://swagger.io/tools/swagger-ui/).
 * Integration test helpers.
+* Generic interface for [use case interactors](https://pkg.go.dev/github.com/swaggest/usecase#NewInteractor). 
 
 ## Usage
 
@@ -51,6 +52,7 @@ Request decoder populates field values from `http.Request` data before use case 
 type helloInput struct {
     Locale string `query:"locale" default:"en-US" pattern:"^[a-z]{2}-[A-Z]{2}$"`
     Name   string `path:"name" minLength:"3"` // Field tags define parameter location and JSON schema constraints.
+	_      string `additionalProperties:"false"` // Field tags of unnamed fields are applied to parent schema.
 }
 ```
 
@@ -85,6 +87,8 @@ r.Method(http.MethodGet, "/hello/{name}", nethttp.NewHandler(u,
 
 Additional field tags describe JSON schema constraints, please check 
 [documentation](https://pkg.go.dev/github.com/swaggest/jsonschema-go#Reflector.Reflect).
+
+More schema customizations are possible with [`github.com/swaggest/jsonschema-go interfaces`](https://github.com/swaggest/jsonschema-go#implementing-interfaces-on-a-type).
 
 By default `default` tags are only contributing to documentation, 
 if [`request.DecoderFactory.ApplyDefaults`](https://pkg.go.dev/github.com/swaggest/rest/request#DecoderFactory) is 

--- a/_examples/advanced-generic/_testdata/openapi.json
+++ b/_examples/advanced-generic/_testdata/openapi.json
@@ -399,19 +399,24 @@
   },
   "components":{
     "schemas":{
-      "AdvancedCustomErr":{"type":"object","properties":{"details":{"type":"object","additionalProperties":{}},"msg":{"type":"string"}}},
+      "AdvancedCustomErr":{
+        "type":"object","properties":{"details":{"type":"object","additionalProperties":{}},"msg":{"type":"string"}},
+        "additionalProperties":false
+      },
       "AdvancedGzipPassThroughStruct":{
         "type":"object",
-        "properties":{"id":{"type":"integer"},"text":{"type":"array","items":{"type":"string"},"nullable":true}}
+        "properties":{"id":{"type":"integer"},"text":{"type":"array","items":{"type":"string"},"nullable":true}},
+        "additionalProperties":false
       },
-      "AdvancedHeaderOutput":{"type":"object","properties":{"inBody":{"type":"string","deprecated":true}}},
+      "AdvancedHeaderOutput":{"type":"object","properties":{"inBody":{"type":"string","deprecated":true}},"additionalProperties":false},
       "AdvancedInfo":{
         "type":"object",
         "properties":{
           "filename":{"type":"string"},"header":{"$ref":"#/components/schemas/TextprotoMIMEHeader"},
           "inQuery":{"type":"integer"},"peek1":{"type":"string"},"peek2":{"type":"string"},"simple":{"type":"string"},
           "size":{"type":"integer"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedInfoType2":{
         "type":"object",
@@ -421,29 +426,40 @@
           "inQuery":{"type":"integer"},"peeks1":{"type":"array","items":{"type":"string"},"nullable":true},
           "peeks2":{"type":"array","items":{"type":"string"},"nullable":true},"simple":{"type":"string"},
           "sizes":{"type":"array","items":{"type":"integer"},"nullable":true}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedInputPortType2":{
         "required":["data"],"type":"object",
         "properties":{
           "data":{
             "type":"object",
-            "properties":{"value":{"minLength":3,"type":"string","description":"Request minLength: 3, response maxLength: 7"}}
+            "properties":{"value":{"minLength":3,"type":"string","description":"Request minLength: 3, response maxLength: 7"}},
+            "additionalProperties":false
           }
-        }
+        },
+        "additionalProperties":false
       },
-      "AdvancedInputPortType3":{"type":"object","properties":{"data":{"type":"object","properties":{"value":{"type":"string"}}}}},
+      "AdvancedInputPortType3":{
+        "type":"object",
+        "properties":{"data":{"type":"object","properties":{"value":{"type":"string"}},"additionalProperties":false}},
+        "additionalProperties":false
+      },
       "AdvancedInputWithJSONType2":{
         "type":"object",
         "properties":{
           "id":{"type":"integer"},"name":{"type":"string"},
           "namedStruct":{"allOf":[{"deprecated":true},{"$ref":"#/components/schemas/AdvancedJSONPayloadType2"}]}
-        }
+        },
+        "additionalProperties":false
       },
-      "AdvancedInputWithJSONType3":{"type":"object","properties":{"id":{"minimum":100,"type":"integer"},"name":{"minLength":3,"type":"string"}}},
+      "AdvancedInputWithJSONType3":{
+        "type":"object","properties":{"id":{"minimum":100,"type":"integer"},"name":{"minLength":3,"type":"string"}},
+        "additionalProperties":false
+      },
       "AdvancedJSONMapPayload":{"type":"object","additionalProperties":{"type":"number"},"nullable":true},
-      "AdvancedJSONPayload":{"type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"}}},
-      "AdvancedJSONPayloadType2":{"type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"}}},
+      "AdvancedJSONPayload":{"type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"}},"additionalProperties":false},
+      "AdvancedJSONPayloadType2":{"type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"}},"additionalProperties":false},
       "AdvancedJSONSlicePayload":{"type":"array","items":{"type":"integer"},"nullable":true},
       "AdvancedJsonMapReq":{"type":"object","additionalProperties":{"type":"number"}},
       "AdvancedJsonOutput":{
@@ -451,39 +467,49 @@
         "properties":{
           "data":{"$ref":"#/components/schemas/AdvancedJSONSlicePayload"},"inHeader":{"type":"string"},
           "inQuery":{"type":"integer"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedJsonOutputType2":{
         "type":"object",
         "properties":{
           "data":{"$ref":"#/components/schemas/AdvancedJSONMapPayload"},"inHeader":{"type":"string"},
           "inQuery":{"type":"integer"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedJsonSliceReq":{"type":"array","items":{"type":"integer"}},
-      "AdvancedOkResp":{"type":"object","properties":{"status":{"type":"string"}}},
+      "AdvancedOkResp":{"type":"object","properties":{"status":{"type":"string"}},"additionalProperties":false},
       "AdvancedOutputPortType2":{
         "required":["data"],"type":"object",
-        "properties":{"data":{"type":"object","properties":{"value":{"maxLength":7,"type":"string"}}}}
+        "properties":{"data":{"type":"object","properties":{"value":{"maxLength":7,"type":"string"}},"additionalProperties":false}},
+        "additionalProperties":false
       },
-      "AdvancedOutputPortType3":{"type":"object","properties":{"data":{"type":"object","properties":{"value":{"type":"string"}}}}},
+      "AdvancedOutputPortType3":{
+        "type":"object",
+        "properties":{"data":{"type":"object","properties":{"value":{"type":"string"}},"additionalProperties":false}},
+        "additionalProperties":false
+      },
       "AdvancedOutputQueryObject":{
         "type":"object",
-        "properties":{"inQuery":{"type":"object","additionalProperties":{"type":"number"},"nullable":true}}
+        "properties":{"inQuery":{"type":"object","additionalProperties":{"type":"number"},"nullable":true}},
+        "additionalProperties":false
       },
       "AdvancedOutputWithJSON":{
         "type":"object",
         "properties":{
           "id":{"type":"integer"},"inHeader":{"type":"string"},"inPath":{"type":"string"},"inQuery":{"type":"integer"},
           "name":{"type":"string"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedOutputWithJSONType2":{
         "type":"object",
         "properties":{
           "id":{"type":"integer"},"inHeader":{"type":"string"},"inPath":{"type":"string"},
           "inQuery":{"type":"string","format":"date","deprecated":true},"name":{"type":"string"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedOutputWithJSONType3":{
         "type":"object",
@@ -491,11 +517,13 @@
           "id":{"minimum":100,"type":"integer"},"inHeader":{"minLength":3,"type":"string"},
           "inPath":{"minLength":3,"type":"string"},"inQuery":{"minimum":3,"type":"integer"},
           "name":{"minLength":3,"type":"string"}
-        }
+        },
+        "additionalProperties":false
       },
       "FormDataAdvancedInputPort":{
         "required":["val2"],"type":"object",
-        "properties":{"val2":{"minimum":3,"type":"integer","description":"Simple scalar value with sample validation."}}
+        "properties":{"val2":{"minimum":3,"type":"integer","description":"Simple scalar value with sample validation."}},
+        "additionalProperties":false
       },
       "FormDataAdvancedUpload":{
         "type":"object",
@@ -503,7 +531,8 @@
           "simple":{"type":"string","description":"Simple scalar value in body."},
           "upload1":{"$ref":"#/components/schemas/FormDataMultipartFileHeader"},
           "upload2":{"$ref":"#/components/schemas/FormDataMultipartFile"}
-        }
+        },
+        "additionalProperties":false
       },
       "FormDataAdvancedUploadType2":{
         "type":"object",
@@ -517,7 +546,8 @@
             "type":"array","items":{"$ref":"#/components/schemas/FormDataMultipartFile"},
             "description":"Uploads with multipart.File.","nullable":true
           }
-        }
+        },
+        "additionalProperties":false
       },
       "FormDataMultipartFile":{"type":"string","format":"binary","nullable":true},
       "FormDataMultipartFileHeader":{"type":"string","format":"binary","nullable":true},

--- a/_examples/advanced-generic/gzip_pass_through_test.go
+++ b/_examples/advanced-generic/gzip_pass_through_test.go
@@ -59,7 +59,7 @@ func Test_directGzip_perf(t *testing.T) {
 		assert.Less(t, res.Extra["B:rcvd/op"], 640.0)
 		assert.Less(t, res.Extra["B:sent/op"], 104.0)
 		assert.Less(t, res.AllocsPerOp(), int64(45))
-		assert.Less(t, res.AllocedBytesPerOp(), int64(4000))
+		assert.Less(t, res.AllocedBytesPerOp(), int64(4100))
 	}
 }
 

--- a/_examples/advanced/_testdata/openapi.json
+++ b/_examples/advanced/_testdata/openapi.json
@@ -395,19 +395,24 @@
   },
   "components":{
     "schemas":{
-      "AdvancedCustomErr":{"type":"object","properties":{"details":{"type":"object","additionalProperties":{}},"msg":{"type":"string"}}},
+      "AdvancedCustomErr":{
+        "type":"object","properties":{"details":{"type":"object","additionalProperties":{}},"msg":{"type":"string"}},
+        "additionalProperties":false
+      },
       "AdvancedGzipPassThroughStruct":{
         "type":"object",
-        "properties":{"id":{"type":"integer"},"text":{"type":"array","items":{"type":"string"},"nullable":true}}
+        "properties":{"id":{"type":"integer"},"text":{"type":"array","items":{"type":"string"},"nullable":true}},
+        "additionalProperties":false
       },
-      "AdvancedHeaderOutput":{"type":"object","properties":{"inBody":{"type":"string","deprecated":true}}},
+      "AdvancedHeaderOutput":{"type":"object","properties":{"inBody":{"type":"string","deprecated":true}},"additionalProperties":false},
       "AdvancedInfo":{
         "type":"object",
         "properties":{
           "filename":{"type":"string"},"header":{"$ref":"#/components/schemas/TextprotoMIMEHeader"},
           "inQuery":{"type":"integer"},"peek1":{"type":"string"},"peek2":{"type":"string"},"simple":{"type":"string"},
           "size":{"type":"integer"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedInfoType2":{
         "type":"object",
@@ -417,29 +422,40 @@
           "inQuery":{"type":"integer"},"peeks1":{"type":"array","items":{"type":"string"},"nullable":true},
           "peeks2":{"type":"array","items":{"type":"string"},"nullable":true},"simple":{"type":"string"},
           "sizes":{"type":"array","items":{"type":"integer"},"nullable":true}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedInputPortType2":{
         "required":["data"],"type":"object",
         "properties":{
           "data":{
             "type":"object",
-            "properties":{"value":{"minLength":3,"type":"string","description":"Request minLength: 3, response maxLength: 7"}}
+            "properties":{"value":{"minLength":3,"type":"string","description":"Request minLength: 3, response maxLength: 7"}},
+            "additionalProperties":false
           }
-        }
+        },
+        "additionalProperties":false
       },
-      "AdvancedInputPortType3":{"type":"object","properties":{"data":{"type":"object","properties":{"value":{"type":"string"}}}}},
+      "AdvancedInputPortType3":{
+        "type":"object",
+        "properties":{"data":{"type":"object","properties":{"value":{"type":"string"}},"additionalProperties":false}},
+        "additionalProperties":false
+      },
       "AdvancedInputWithJSONType2":{
         "type":"object",
         "properties":{
           "id":{"type":"integer"},"name":{"type":"string"},
           "namedStruct":{"allOf":[{"deprecated":true},{"$ref":"#/components/schemas/AdvancedJSONPayloadType2"}]}
-        }
+        },
+        "additionalProperties":false
       },
-      "AdvancedInputWithJSONType3":{"type":"object","properties":{"id":{"minimum":100,"type":"integer"},"name":{"minLength":3,"type":"string"}}},
+      "AdvancedInputWithJSONType3":{
+        "type":"object","properties":{"id":{"minimum":100,"type":"integer"},"name":{"minLength":3,"type":"string"}},
+        "additionalProperties":false
+      },
       "AdvancedJSONMapPayload":{"type":"object","additionalProperties":{"type":"number"},"nullable":true},
-      "AdvancedJSONPayload":{"type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"}}},
-      "AdvancedJSONPayloadType2":{"type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"}}},
+      "AdvancedJSONPayload":{"type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"}},"additionalProperties":false},
+      "AdvancedJSONPayloadType2":{"type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"}},"additionalProperties":false},
       "AdvancedJSONSlicePayload":{"type":"array","items":{"type":"integer"},"nullable":true},
       "AdvancedJsonMapReq":{"type":"object","additionalProperties":{"type":"number"},"nullable":true},
       "AdvancedJsonOutput":{
@@ -447,39 +463,49 @@
         "properties":{
           "data":{"$ref":"#/components/schemas/AdvancedJSONSlicePayload"},"inHeader":{"type":"string"},
           "inQuery":{"type":"integer"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedJsonOutputType2":{
         "type":"object",
         "properties":{
           "data":{"$ref":"#/components/schemas/AdvancedJSONMapPayload"},"inHeader":{"type":"string"},
           "inQuery":{"type":"integer"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedJsonSliceReq":{"type":"array","items":{"type":"integer"},"nullable":true},
-      "AdvancedOkResp":{"type":"object","properties":{"status":{"type":"string"}}},
+      "AdvancedOkResp":{"type":"object","properties":{"status":{"type":"string"}},"additionalProperties":false},
       "AdvancedOutputPortType2":{
         "required":["data"],"type":"object",
-        "properties":{"data":{"type":"object","properties":{"value":{"maxLength":7,"type":"string"}}}}
+        "properties":{"data":{"type":"object","properties":{"value":{"maxLength":7,"type":"string"}},"additionalProperties":false}},
+        "additionalProperties":false
       },
-      "AdvancedOutputPortType3":{"type":"object","properties":{"data":{"type":"object","properties":{"value":{"type":"string"}}}}},
+      "AdvancedOutputPortType3":{
+        "type":"object",
+        "properties":{"data":{"type":"object","properties":{"value":{"type":"string"}},"additionalProperties":false}},
+        "additionalProperties":false
+      },
       "AdvancedOutputQueryObject":{
         "type":"object",
-        "properties":{"inQuery":{"type":"object","additionalProperties":{"type":"number"},"nullable":true}}
+        "properties":{"inQuery":{"type":"object","additionalProperties":{"type":"number"},"nullable":true}},
+        "additionalProperties":false
       },
       "AdvancedOutputWithJSON":{
         "type":"object",
         "properties":{
           "id":{"type":"integer"},"inHeader":{"type":"string"},"inPath":{"type":"string"},"inQuery":{"type":"integer"},
           "name":{"type":"string"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedOutputWithJSONType2":{
         "type":"object",
         "properties":{
           "id":{"type":"integer"},"inHeader":{"type":"string"},"inPath":{"type":"string"},
           "inQuery":{"type":"string","format":"date","deprecated":true},"name":{"type":"string"}
-        }
+        },
+        "additionalProperties":false
       },
       "AdvancedOutputWithJSONType3":{
         "type":"object",
@@ -487,11 +513,13 @@
           "id":{"minimum":100,"type":"integer"},"inHeader":{"minLength":3,"type":"string"},
           "inPath":{"minLength":3,"type":"string"},"inQuery":{"minimum":3,"type":"integer"},
           "name":{"minLength":3,"type":"string"}
-        }
+        },
+        "additionalProperties":false
       },
       "FormDataAdvancedInputPort":{
         "required":["val2"],"type":"object",
-        "properties":{"val2":{"minimum":3,"type":"integer","description":"Simple scalar value with sample validation."}}
+        "properties":{"val2":{"minimum":3,"type":"integer","description":"Simple scalar value with sample validation."}},
+        "additionalProperties":false
       },
       "FormDataAdvancedUpload":{
         "type":"object",
@@ -499,7 +527,8 @@
           "simple":{"type":"string","description":"Simple scalar value in body."},
           "upload1":{"$ref":"#/components/schemas/FormDataMultipartFileHeader"},
           "upload2":{"$ref":"#/components/schemas/FormDataMultipartFile"}
-        }
+        },
+        "additionalProperties":false
       },
       "FormDataAdvancedUploadType2":{
         "type":"object",
@@ -513,7 +542,8 @@
             "type":"array","items":{"$ref":"#/components/schemas/FormDataMultipartFile"},
             "description":"Uploads with multipart.File.","nullable":true
           }
-        }
+        },
+        "additionalProperties":false
       },
       "FormDataMultipartFile":{"type":"string","format":"binary","nullable":true},
       "FormDataMultipartFileHeader":{"type":"string","format":"binary","nullable":true},

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.7.1
 	github.com/swaggest/assertjson v1.6.8
-	github.com/swaggest/jsonschema-go v0.3.30
+	github.com/swaggest/jsonschema-go v0.3.31
 	github.com/swaggest/openapi-go v0.2.15
 	github.com/swaggest/swgui v1.4.5
 	github.com/swaggest/usecase v1.1.2
@@ -33,7 +33,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v3 v3.1.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/swaggest/form/v5 v5.0.1 // indirect
-	github.com/swaggest/refl v1.0.1 // indirect
+	github.com/swaggest/refl v1.0.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/vearutop/statigz v1.1.5 // indirect
 	github.com/yosuke-furukawa/json5 v0.1.2-0.20201207051438-cf7bb3f354ff // indirect

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -6,7 +6,6 @@ github.com/bool64/ctxd v1.1.2/go.mod h1:5rwLykeZBJHK27q5sSfhfKig6076270V+3iiXbP+
 github.com/bool64/dev v0.1.25/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.1.35/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.1.41/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
-github.com/bool64/dev v0.1.42/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.2.5/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.2.10 h1:ypAGBazcwyIy2JvIJio8V3kdqO7AgIAYvcckW54qxr4=
 github.com/bool64/dev v0.2.10/go.mod h1:/csLrm+4oDSsKJRIVS0mrywAonLnYKFG8RvGT7Jh9b8=
@@ -82,12 +81,12 @@ github.com/swaggest/assertjson v1.6.8 h1:1O/9UI5M+2OJI7BeEWKGj0wTvpRXZt5FkOJ4nRk
 github.com/swaggest/assertjson v1.6.8/go.mod h1:Euf0upn9Vlaf1/llYHTs+Kx5K3vVbpMbsZhth7zlN7M=
 github.com/swaggest/form/v5 v5.0.1 h1:YQH0REX7iMKhtoVPWXREZgbt50VYXNCKK61psnD8Fgo=
 github.com/swaggest/form/v5 v5.0.1/go.mod h1:vdnaSTze7cxVKhWiCabrfm1YeLwWLpb9P941Gxv4FnA=
-github.com/swaggest/jsonschema-go v0.3.30 h1:ZBfKebjPZy7jKU2MvW9N7YmpYldFADr+VCmtgYz83cw=
-github.com/swaggest/jsonschema-go v0.3.30/go.mod h1:pu+U4tVOkJ2hYTY8PlUnNz6+gzFdNyXnEFZtQlELtwc=
+github.com/swaggest/jsonschema-go v0.3.31 h1:PMgghRyVEphrEsVX+3KByWUW3u42gmRN875S3MLedxY=
+github.com/swaggest/jsonschema-go v0.3.31/go.mod h1:JAF1nm+uIaMOXktuQepmkiRcgQ5yJk4Ccwx9HVt2cXw=
 github.com/swaggest/openapi-go v0.2.15 h1:Cp3c0IacJlDEvYYCBzVm3M51bINyI2XCH5RAwulSj/E=
 github.com/swaggest/openapi-go v0.2.15/go.mod h1:3Xd0go1dJkxlSlBHpVV3h76TccououBojV98hhXn6eQ=
-github.com/swaggest/refl v1.0.1 h1:YQHb7Ic6EMpdUpxQmTWmf/O4IWN6iIErxJNWA7LwyyM=
-github.com/swaggest/refl v1.0.1/go.mod h1:dnx+n9YaI0o+FH+OR2tJZWLABBVIPs9qc4VY9UdrhLE=
+github.com/swaggest/refl v1.0.2 h1:VmP8smuDS1EzUPn31++TzMi13CAaVJdlWpIxzj0up88=
+github.com/swaggest/refl v1.0.2/go.mod h1:DoiPoBJPYHU6Z9fIA6zXQ9uI6VRL6M8BFX5YFT+ym9g=
 github.com/swaggest/swgui v1.4.5 h1:9kw3Lt+4qNdDwnRgpNSsx3s3BjoW/Inhbn7/38DX6Qk=
 github.com/swaggest/swgui v1.4.5/go.mod h1:qfAwdL49ikzxahZrLrPJYAruNuL1Nt6do8jtC9luAlI=
 github.com/swaggest/usecase v1.1.2 h1:2LfuSyjYtPtpHnxqPwV87/eunbhGBC5HKdRp8/fINBk=

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/swaggest/assertjson v1.6.8
 	github.com/swaggest/form/v5 v5.0.1
-	github.com/swaggest/jsonschema-go v0.3.30
+	github.com/swaggest/jsonschema-go v0.3.31
 	github.com/swaggest/openapi-go v0.2.15
-	github.com/swaggest/refl v1.0.1
+	github.com/swaggest/refl v1.0.2
 	github.com/swaggest/usecase v1.1.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -73,13 +73,14 @@ github.com/swaggest/assertjson v1.6.8/go.mod h1:Euf0upn9Vlaf1/llYHTs+Kx5K3vVbpMb
 github.com/swaggest/form/v5 v5.0.1 h1:YQH0REX7iMKhtoVPWXREZgbt50VYXNCKK61psnD8Fgo=
 github.com/swaggest/form/v5 v5.0.1/go.mod h1:vdnaSTze7cxVKhWiCabrfm1YeLwWLpb9P941Gxv4FnA=
 github.com/swaggest/jsonschema-go v0.3.24/go.mod h1:B2ZSqrrlkj21zhywlkh8VnKBmuqUwDv3dLQoPjgHk7M=
-github.com/swaggest/jsonschema-go v0.3.30 h1:ZBfKebjPZy7jKU2MvW9N7YmpYldFADr+VCmtgYz83cw=
-github.com/swaggest/jsonschema-go v0.3.30/go.mod h1:pu+U4tVOkJ2hYTY8PlUnNz6+gzFdNyXnEFZtQlELtwc=
+github.com/swaggest/jsonschema-go v0.3.31 h1:PMgghRyVEphrEsVX+3KByWUW3u42gmRN875S3MLedxY=
+github.com/swaggest/jsonschema-go v0.3.31/go.mod h1:JAF1nm+uIaMOXktuQepmkiRcgQ5yJk4Ccwx9HVt2cXw=
 github.com/swaggest/openapi-go v0.2.15 h1:Cp3c0IacJlDEvYYCBzVm3M51bINyI2XCH5RAwulSj/E=
 github.com/swaggest/openapi-go v0.2.15/go.mod h1:3Xd0go1dJkxlSlBHpVV3h76TccououBojV98hhXn6eQ=
 github.com/swaggest/refl v1.0.0/go.mod h1:acYd5x8NNxivp+ZHdRZKJYz66n/qjo3Q9Sa/jAivljQ=
-github.com/swaggest/refl v1.0.1 h1:YQHb7Ic6EMpdUpxQmTWmf/O4IWN6iIErxJNWA7LwyyM=
 github.com/swaggest/refl v1.0.1/go.mod h1:dnx+n9YaI0o+FH+OR2tJZWLABBVIPs9qc4VY9UdrhLE=
+github.com/swaggest/refl v1.0.2 h1:VmP8smuDS1EzUPn31++TzMi13CAaVJdlWpIxzj0up88=
+github.com/swaggest/refl v1.0.2/go.mod h1:DoiPoBJPYHU6Z9fIA6zXQ9uI6VRL6M8BFX5YFT+ym9g=
 github.com/swaggest/usecase v1.1.2 h1:2LfuSyjYtPtpHnxqPwV87/eunbhGBC5HKdRp8/fINBk=
 github.com/swaggest/usecase v1.1.2/go.mod h1:abZWuMFYujaeLDODqRySJZpWD/ugsnE3Wj9K6jUeCjo=
 github.com/yosuke-furukawa/json5 v0.1.2-0.20201207051438-cf7bb3f354ff h1:7YqG491bE4vstXRz1lD38rbSgbXnirvROz1lZiOnPO8=


### PR DESCRIPTION
This PR adds an example of global schema interceptor to set `additionalProperties: false` for all relevant schemas.

```go
	// An example of global schema override to disable additionalProperties for all object schemas.
	s.OpenAPICollector.Reflector().DefaultOptions = append(s.OpenAPICollector.Reflector().DefaultOptions, func(rc *jsonschema.ReflectContext) {
		it := rc.InterceptType
		rc.InterceptType = func(value reflect.Value, schema *jsonschema.Schema) (bool, error) {
			stop, err := it(value, schema)
			if err != nil {
				return stop, err
			}

			if schema.HasType(jsonschema.Object) && len(schema.Properties) > 0 && schema.AdditionalProperties == nil {
				schema.AdditionalProperties = (&jsonschema.SchemaOrBool{}).WithTypeBoolean(false)
			}

			return stop, nil
		}
	})
```