### PR TITLE
Tolerate form-data for request bodies with json tags

### DIFF
--- a/request/factory.go
+++ b/request/factory.go
@@ -130,13 +130,15 @@ func (df *DecoderFactory) MakeDecoder(
 		return &m
 	}
 
+	hasFormData := refl.HasTaggedFields(input, formDataTag)
+
 	// Checking for body tags.
 	if refl.HasTaggedFields(input, jsonTag) || refl.FindEmbeddedSliceOrMap(input) != nil ||
 		refl.IsSliceOrMap(input) || refl.IsScalar(input) {
 		if df.JSONReader != nil {
-			m.decoders = append(m.decoders, decodeJSONBody(df.JSONReader))
+			m.decoders = append(m.decoders, decodeJSONBody(df.JSONReader, hasFormData))
 		} else {
-			m.decoders = append(m.decoders, decodeJSONBody(readJSON))
+			m.decoders = append(m.decoders, decodeJSONBody(readJSON, hasFormData))
 		}
 
 		m.in = append(m.in, rest.ParamInBody)

--- a/request/jsonbody.go
+++ b/request/jsonbody.go
@@ -23,17 +23,14 @@ func readJSON(rd io.Reader, v interface{}) error {
 	return d.Decode(v)
 }
 
-func decodeJSONBody(readJSON func(rd io.Reader, v interface{}) error) valueDecoderFunc {
+func decodeJSONBody(readJSON func(rd io.Reader, v interface{}) error, tolerateFormData bool) valueDecoderFunc {
 	return func(r *http.Request, input interface{}, validator rest.Validator) error {
 		if r.ContentLength == 0 {
 			return ErrMissingRequestBody
 		}
 
-		contentType := r.Header.Get("Content-Type")
-		if contentType != "" {
-			if len(contentType) < 16 || contentType[0:16] != "application/json" { // allow 'application/json;charset=UTF-8'
-				return fmt.Errorf("%w, received: %s", ErrJSONExpected, contentType)
-			}
+		if err := checkJSONBodyContentType(r.Header.Get("Content-Type"), tolerateFormData); err != nil {
+			return err
 		}
 
 		var (
@@ -65,4 +62,20 @@ func decodeJSONBody(readJSON func(rd io.Reader, v interface{}) error) valueDecod
 
 		return nil
 	}
+}
+
+func checkJSONBodyContentType(contentType string, tolerateFormData bool) error {
+	if contentType == "" {
+		return nil
+	}
+
+	if len(contentType) < 16 || contentType[0:16] != "application/json" { // allow 'application/json;charset=UTF-8'
+		if tolerateFormData && (contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data") {
+			return nil
+		}
+
+		return fmt.Errorf("%w, received: %s", ErrJSONExpected, contentType)
+	}
+
+	return nil
 }

--- a/request/jsonbody_test.go
+++ b/request/jsonbody_test.go
@@ -97,3 +97,23 @@ func Test_decodeJSONBody_validateFailed(t *testing.T) {
 	err = decodeJSONBody(readJSON, false)(req, &i, vl)
 	assert.EqualError(t, err, "failed")
 }
+
+func Test_decodeJSONBody_tolerateFormData(t *testing.T) {
+	createBody := bytes.NewReader(
+		[]byte(`amount=123&customerId=248df4b7-aa70-47b8-a036-33ac447e668d&type=withdraw`))
+	createReq, err := http.NewRequest(http.MethodPost, "/US/order/348df4b7-aa70-47b8-a036-33ac447e668d", createBody)
+	createReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	assert.NoError(t, err)
+
+	type Input struct {
+		Amount     int    `json:"amount" formData:"amount"`
+		CustomerID string `json:"customerId" formData:"customerId"`
+		Type       string `json:"type" formData:"type"`
+	}
+
+	i := Input{}
+	assert.NoError(t, decodeJSONBody(readJSON, true)(createReq, &i, nil))
+	assert.Empty(t, i.Amount)
+	assert.Empty(t, i.CustomerID)
+	assert.Empty(t, i.Type)
+}

--- a/request/jsonbody_test.go
+++ b/request/jsonbody_test.go
@@ -25,7 +25,7 @@ func Test_decodeJSONBody(t *testing.T) {
 	}
 
 	i := Input{}
-	assert.NoError(t, decodeJSONBody(readJSON)(createReq, &i, nil))
+	assert.NoError(t, decodeJSONBody(readJSON, false)(createReq, &i, nil))
 	assert.Equal(t, 123, i.Amount)
 	assert.Equal(t, "248df4b7-aa70-47b8-a036-33ac447e668d", i.CustomerID)
 	assert.Equal(t, "withdraw", i.Type)
@@ -37,7 +37,7 @@ func Test_decodeJSONBody(t *testing.T) {
 	i = Input{}
 	_, err = createBody.Seek(0, io.SeekStart)
 	assert.NoError(t, err)
-	assert.NoError(t, decodeJSONBody(readJSON)(createReq, &i, vl))
+	assert.NoError(t, decodeJSONBody(readJSON, false)(createReq, &i, vl))
 	assert.Equal(t, 123, i.Amount)
 	assert.Equal(t, "248df4b7-aa70-47b8-a036-33ac447e668d", i.CustomerID)
 	assert.Equal(t, "withdraw", i.Type)
@@ -49,7 +49,7 @@ func Test_decodeJSONBody_emptyBody(t *testing.T) {
 
 	var i []int
 
-	err = decodeJSONBody(readJSON)(req, &i, nil)
+	err = decodeJSONBody(readJSON, false)(req, &i, nil)
 	assert.EqualError(t, err, "missing request body")
 }
 
@@ -60,7 +60,7 @@ func Test_decodeJSONBody_badContentType(t *testing.T) {
 
 	var i []int
 
-	err = decodeJSONBody(readJSON)(req, &i, nil)
+	err = decodeJSONBody(readJSON, false)(req, &i, nil)
 	assert.EqualError(t, err, "request with application/json content type expected, received: text/plain")
 }
 
@@ -70,7 +70,7 @@ func Test_decodeJSONBody_decodeFailed(t *testing.T) {
 
 	var i []int
 
-	err = decodeJSONBody(readJSON)(req, &i, nil)
+	err = decodeJSONBody(readJSON, false)(req, &i, nil)
 	assert.Error(t, err)
 }
 
@@ -80,7 +80,7 @@ func Test_decodeJSONBody_unmarshalFailed(t *testing.T) {
 
 	var i []int
 
-	err = decodeJSONBody(readJSON)(req, &i, nil)
+	err = decodeJSONBody(readJSON, false)(req, &i, nil)
 	assert.EqualError(t, err, "failed to decode json: json: cannot unmarshal number into Go value of type []int")
 }
 
@@ -94,6 +94,6 @@ func Test_decodeJSONBody_validateFailed(t *testing.T) {
 		return errors.New("failed")
 	})
 
-	err = decodeJSONBody(readJSON)(req, &i, vl)
+	err = decodeJSONBody(readJSON, false)(req, &i, vl)
 	assert.EqualError(t, err, "failed")
 }


### PR DESCRIPTION
This PR fixes behavior of handling structures that have both `formData` and `json` field tags.