### PR TITLE
Return wrappers support in Use and With (filtered) to fix sub-routers

### DIFF
--- a/_examples/advanced-generic/_testdata/openapi.json
+++ b/_examples/advanced-generic/_testdata/openapi.json
@@ -2,6 +2,32 @@
   "openapi":"3.0.3",
   "info":{"title":"Advanced Example","description":"This app showcases a variety of features.","version":"v1.2.3"},
   "paths":{
+    "/deeper-with-session/one":{
+      "get":{
+        "summary":"Dummy","operationId":"_examples/advanced-generic.dummy2",
+        "responses":{
+          "204":{"description":"No Content"},
+          "401":{
+            "description":"Unauthorized",
+            "content":{"application/json":{"schema":{"$ref":"#/components/schemas/RestErrResponse"}}}
+          }
+        },
+        "security":[{"User":[]}]
+      }
+    },
+    "/deeper-with-session/two":{
+      "get":{
+        "summary":"Dummy","operationId":"_examples/advanced-generic.dummy3",
+        "responses":{
+          "204":{"description":"No Content"},
+          "401":{
+            "description":"Unauthorized",
+            "content":{"application/json":{"schema":{"$ref":"#/components/schemas/RestErrResponse"}}}
+          }
+        },
+        "security":[{"User":[]}]
+      }
+    },
     "/error-response":{
       "get":{
         "summary":"Declare Expected Errors",
@@ -427,6 +453,19 @@
         }
       }
     },
+    "/root-with-session":{
+      "get":{
+        "summary":"Dummy","operationId":"_examples/advanced-generic.dummy",
+        "responses":{
+          "204":{"description":"No Content"},
+          "401":{
+            "description":"Unauthorized",
+            "content":{"application/json":{"schema":{"$ref":"#/components/schemas/RestErrResponse"}}}
+          }
+        },
+        "security":[{"User":[]}]
+      }
+    },
     "/validation":{
       "post":{
         "summary":"Validation","description":"Input/Output with validation. Custom annotation.",
@@ -617,8 +656,18 @@
       },
       "FormDataMultipartFile":{"type":"string","format":"binary","nullable":true},
       "FormDataMultipartFileHeader":{"type":"string","format":"binary","nullable":true},
+      "RestErrResponse":{
+        "type":"object",
+        "properties":{
+          "code":{"type":"integer","description":"Application-specific error code."},
+          "context":{"type":"object","additionalProperties":{},"description":"Application context."},
+          "error":{"type":"string","description":"Error message."},
+          "status":{"type":"string","description":"Status text."}
+        }
+      },
       "TextprotoMIMEHeader":{"type":"object","additionalProperties":{"type":"array","items":{"type":"string"}},"nullable":true},
       "UuidUUID":{"type":"string","format":"uuid","example":"248df4b7-aa70-47b8-a036-33ac447e668d"}
-    }
+    },
+    "securitySchemes":{"User":{"type":"apiKey","name":"sessid","in":"cookie"}}
   }
 }

--- a/_examples/advanced-generic/dummy.go
+++ b/_examples/advanced-generic/dummy.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"context"
+
+	"github.com/swaggest/usecase"
+)
+
+func dummy() usecase.Interactor {
+	return usecase.NewInteractor(func(ctx context.Context, input struct{}, output *struct{}) error {
+		return nil
+	})
+}

--- a/_examples/advanced-generic/router.go
+++ b/_examples/advanced-generic/router.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/rs/cors"
 	"github.com/swaggest/jsonschema-go"
@@ -165,6 +166,37 @@ func NewRouter() http.Handler {
 	s.Head("/gzip-pass-through", directGzip())
 
 	s.Get("/error-response", errorResponse())
+
+	// Security middlewares.
+	//  - sessMW is the actual request-level processor,
+	//  - sessDoc is a handler-level wrapper to expose docs.
+	sessMW := func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if c, err := r.Cookie("sessid"); err == nil {
+				r = r.WithContext(context.WithValue(r.Context(), "sessionID", c.Value))
+			}
+		})
+	}
+
+	sessDoc := nethttp.SecurityMiddleware(s.OpenAPICollector, "User", openapi3.SecurityScheme{
+		APIKeySecurityScheme: &openapi3.APIKeySecurityScheme{
+			In:   "cookie",
+			Name: "sessid",
+		},
+	})
+
+	// Security schema is configured for a single top-level route.
+	s.With(sessMW, sessDoc).Method(http.MethodGet, "/root-with-session", nethttp.NewHandler(dummy()))
+
+	// Security schema is configured on a sub-router.
+	s.Route("/deeper-with-session", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(sessMW, sessDoc)
+
+			r.Method(http.MethodGet, "/one", nethttp.NewHandler(dummy()))
+			r.Method(http.MethodGet, "/two", nethttp.NewHandler(dummy()))
+		})
+	})
 
 	// Swagger UI endpoint at /docs.
 	s.Docs("/docs", swgui.New)

--- a/_examples/advanced/_testdata/openapi.json
+++ b/_examples/advanced/_testdata/openapi.json
@@ -2,6 +2,32 @@
   "openapi":"3.0.3",
   "info":{"title":"Advanced Example","description":"This app showcases a variety of features.","version":"v1.2.3"},
   "paths":{
+    "/deeper-with-session/one":{
+      "get":{
+        "summary":"Dummy","operationId":"_examples/advanced.dummy2",
+        "responses":{
+          "204":{"description":"No Content"},
+          "401":{
+            "description":"Unauthorized",
+            "content":{"application/json":{"schema":{"$ref":"#/components/schemas/RestErrResponse"}}}
+          }
+        },
+        "security":[{"User":[]}]
+      }
+    },
+    "/deeper-with-session/two":{
+      "get":{
+        "summary":"Dummy","operationId":"_examples/advanced.dummy3",
+        "responses":{
+          "204":{"description":"No Content"},
+          "401":{
+            "description":"Unauthorized",
+            "content":{"application/json":{"schema":{"$ref":"#/components/schemas/RestErrResponse"}}}
+          }
+        },
+        "security":[{"User":[]}]
+      }
+    },
     "/error-response":{
       "get":{
         "summary":"Declare Expected Errors",
@@ -380,6 +406,19 @@
         }
       }
     },
+    "/root-with-session":{
+      "get":{
+        "summary":"Dummy","operationId":"_examples/advanced.dummy",
+        "responses":{
+          "204":{"description":"No Content"},
+          "401":{
+            "description":"Unauthorized",
+            "content":{"application/json":{"schema":{"$ref":"#/components/schemas/RestErrResponse"}}}
+          }
+        },
+        "security":[{"User":[]}]
+      }
+    },
     "/validation":{
       "post":{
         "summary":"Validation","description":"Input/Output with validation. Custom annotation.",
@@ -554,8 +593,18 @@
       },
       "FormDataMultipartFile":{"type":"string","format":"binary","nullable":true},
       "FormDataMultipartFileHeader":{"type":"string","format":"binary","nullable":true},
+      "RestErrResponse":{
+        "type":"object",
+        "properties":{
+          "code":{"type":"integer","description":"Application-specific error code."},
+          "context":{"type":"object","additionalProperties":{},"description":"Application context."},
+          "error":{"type":"string","description":"Error message."},
+          "status":{"type":"string","description":"Status text."}
+        }
+      },
       "TextprotoMIMEHeader":{"type":"object","additionalProperties":{"type":"array","items":{"type":"string"}},"nullable":true},
       "UuidUUID":{"type":"string","format":"uuid","example":"248df4b7-aa70-47b8-a036-33ac447e668d"}
-    }
+    },
+    "securitySchemes":{"User":{"type":"apiKey","name":"sessid","in":"cookie"}}
   }
 }

--- a/_examples/advanced/dummy.go
+++ b/_examples/advanced/dummy.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"context"
+
+	"github.com/swaggest/usecase"
+)
+
+func dummy() usecase.Interactor {
+	return usecase.NewIOI(nil, nil, func(ctx context.Context, input, output interface{}) error {
+		return nil
+	})
+}

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/rs/cors v1.8.2
 	github.com/stretchr/testify v1.8.1
 	github.com/swaggest/assertjson v1.7.0
-	github.com/swaggest/jsonschema-go v0.3.40
-	github.com/swaggest/openapi-go v0.2.24
+	github.com/swaggest/jsonschema-go v0.3.41
+	github.com/swaggest/openapi-go v0.2.25
 	github.com/swaggest/swgui v1.5.1
 	github.com/swaggest/usecase v1.2.0
 	github.com/valyala/fasthttp v1.41.0

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -62,10 +62,10 @@ github.com/swaggest/assertjson v1.7.0 h1:SKw5Rn0LQs6UvmGrIdaKQbMR1R3ncXm5KNon+QJ
 github.com/swaggest/assertjson v1.7.0/go.mod h1:vxMJMehbSVJd+dDWFCKv3QRZKNTpy/ktZKTz9LOEDng=
 github.com/swaggest/form/v5 v5.0.1 h1:YQH0REX7iMKhtoVPWXREZgbt50VYXNCKK61psnD8Fgo=
 github.com/swaggest/form/v5 v5.0.1/go.mod h1:vdnaSTze7cxVKhWiCabrfm1YeLwWLpb9P941Gxv4FnA=
-github.com/swaggest/jsonschema-go v0.3.40 h1:9EqQ9RvtdW69xfYODmyEKWOSZ12x5eiK+wGD2EVh/L4=
-github.com/swaggest/jsonschema-go v0.3.40/go.mod h1:ipIOmoFP64QyRUgyPyU/P9tayq2m2TlvUhyZHrhe3S4=
-github.com/swaggest/openapi-go v0.2.24 h1:Y+IyBMOKUmiSQw6EZs0JhsAjrTo7z/c4ZGy/qQbpHTs=
-github.com/swaggest/openapi-go v0.2.24/go.mod h1:6wX+vfa/g9NW5TXeez3AbqRAphq5PQe9iSqGmOJoplE=
+github.com/swaggest/jsonschema-go v0.3.41 h1:YsrBk5TW+S7/jTudvo1jWUJTECAIBdfk4iM7O9kzbnU=
+github.com/swaggest/jsonschema-go v0.3.41/go.mod h1:yt5lcjdqywYtNnzkFgYnyfvMwlH2XHEDitKw749AV1w=
+github.com/swaggest/openapi-go v0.2.25 h1:CFTbqMxjhD5MMtN6izHkcQuJZoCxQLsN7Zi0zvYTsF8=
+github.com/swaggest/openapi-go v0.2.25/go.mod h1:99jn0HbbECG97hkP6X8BA+TBS4+EBlMuko4zkPAz1BA=
 github.com/swaggest/refl v1.1.0 h1:a+9a75Kv6ciMozPjVbOfcVTEQe81t2R3emvaD9oGQGc=
 github.com/swaggest/refl v1.1.0/go.mod h1:g3Qa6ki0A/L2yxiuUpT+cuBURuRaltF5SDQpg1kMZSY=
 github.com/swaggest/swgui v1.5.1 h1:CXJ2l9n1nEz2AJXl/FHDGD5ZtlKnTRJb2p86njBfXfo=

--- a/chirouter/wrapper.go
+++ b/chirouter/wrapper.go
@@ -55,12 +55,24 @@ func (r *Wrapper) Wrap(wraps ...func(handler http.Handler) http.Handler) {
 func (r *Wrapper) Use(middlewares ...func(http.Handler) http.Handler) {
 	r.Router.Use(middlewares...)
 	r.middlewares = append(r.middlewares, middlewares...)
+
+	for _, mw := range middlewares {
+		if nethttp.MiddlewareIsWrapper(mw) {
+			r.wraps = append(r.wraps, mw)
+		}
+	}
 }
 
 // With adds inline middlewares for an endpoint handler.
 func (r Wrapper) With(middlewares ...func(http.Handler) http.Handler) chi.Router {
 	c := r.copy(r.Router.With(middlewares...), "")
 	c.middlewares = append(c.middlewares, middlewares...)
+
+	for _, mw := range middlewares {
+		if nethttp.MiddlewareIsWrapper(mw) {
+			c.wraps = append(c.wraps, mw)
+		}
+	}
 
 	return c
 }

--- a/chirouter/wrapper_test.go
+++ b/chirouter/wrapper_test.go
@@ -124,7 +124,7 @@ func TestNewWrapper(t *testing.T) {
 	}
 
 	assert.Equal(t, 14, handlersCnt)
-	assert.Equal(t, 20, totalCnt)
+	assert.Equal(t, 21, totalCnt)
 }
 
 func TestWrapper_Use_precedence(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/swaggest/assertjson v1.7.0
 	github.com/swaggest/form/v5 v5.0.1
-	github.com/swaggest/jsonschema-go v0.3.40
-	github.com/swaggest/openapi-go v0.2.24
+	github.com/swaggest/jsonschema-go v0.3.41
+	github.com/swaggest/openapi-go v0.2.25
 	github.com/swaggest/refl v1.1.0
 	github.com/swaggest/usecase v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/bool64/dev v0.2.5/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zR
 github.com/bool64/dev v0.2.10/go.mod h1:/csLrm+4oDSsKJRIVS0mrywAonLnYKFG8RvGT7Jh9b8=
 github.com/bool64/dev v0.2.16/go.mod h1:/csLrm+4oDSsKJRIVS0mrywAonLnYKFG8RvGT7Jh9b8=
 github.com/bool64/dev v0.2.17/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
-github.com/bool64/dev v0.2.19/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/dev v0.2.20/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
+github.com/bool64/dev v0.2.21/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/dev v0.2.22 h1:YJFKBRKplkt+0Emq/5Xk1Z5QRmMNzc1UOJkR3rxJksA=
 github.com/bool64/dev v0.2.22/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/httpmock v0.1.6 h1:v9+AmoSabaHuR7abjnhGwGxsaNljtFAYtluF0p4Q3ng=
@@ -76,10 +76,10 @@ github.com/swaggest/assertjson v1.7.0 h1:SKw5Rn0LQs6UvmGrIdaKQbMR1R3ncXm5KNon+QJ
 github.com/swaggest/assertjson v1.7.0/go.mod h1:vxMJMehbSVJd+dDWFCKv3QRZKNTpy/ktZKTz9LOEDng=
 github.com/swaggest/form/v5 v5.0.1 h1:YQH0REX7iMKhtoVPWXREZgbt50VYXNCKK61psnD8Fgo=
 github.com/swaggest/form/v5 v5.0.1/go.mod h1:vdnaSTze7cxVKhWiCabrfm1YeLwWLpb9P941Gxv4FnA=
-github.com/swaggest/jsonschema-go v0.3.40 h1:9EqQ9RvtdW69xfYODmyEKWOSZ12x5eiK+wGD2EVh/L4=
-github.com/swaggest/jsonschema-go v0.3.40/go.mod h1:ipIOmoFP64QyRUgyPyU/P9tayq2m2TlvUhyZHrhe3S4=
-github.com/swaggest/openapi-go v0.2.24 h1:Y+IyBMOKUmiSQw6EZs0JhsAjrTo7z/c4ZGy/qQbpHTs=
-github.com/swaggest/openapi-go v0.2.24/go.mod h1:6wX+vfa/g9NW5TXeez3AbqRAphq5PQe9iSqGmOJoplE=
+github.com/swaggest/jsonschema-go v0.3.41 h1:YsrBk5TW+S7/jTudvo1jWUJTECAIBdfk4iM7O9kzbnU=
+github.com/swaggest/jsonschema-go v0.3.41/go.mod h1:yt5lcjdqywYtNnzkFgYnyfvMwlH2XHEDitKw749AV1w=
+github.com/swaggest/openapi-go v0.2.25 h1:CFTbqMxjhD5MMtN6izHkcQuJZoCxQLsN7Zi0zvYTsF8=
+github.com/swaggest/openapi-go v0.2.25/go.mod h1:99jn0HbbECG97hkP6X8BA+TBS4+EBlMuko4zkPAz1BA=
 github.com/swaggest/refl v1.1.0 h1:a+9a75Kv6ciMozPjVbOfcVTEQe81t2R3emvaD9oGQGc=
 github.com/swaggest/refl v1.1.0/go.mod h1:g3Qa6ki0A/L2yxiuUpT+cuBURuRaltF5SDQpg1kMZSY=
 github.com/swaggest/usecase v1.2.0 h1:cHVFqxIbHfyTXp02JmWXk+ZADaSa87UZP+b3qL5Nz90=

--- a/nethttp/handler.go
+++ b/nethttp/handler.go
@@ -229,6 +229,10 @@ func (h handlerWithRoute) RoutePattern() string {
 // HandlerWithRouteMiddleware wraps handler with routing information.
 func HandlerWithRouteMiddleware(method, pathPattern string) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
+		if IsWrapperChecker(handler) {
+			return handler
+		}
+
 		return handlerWithRoute{
 			Handler:     handler,
 			pathPattern: pathPattern,

--- a/nethttp/openapi.go
+++ b/nethttp/openapi.go
@@ -106,6 +106,10 @@ func AnnotateOpenAPI(
 	setup ...func(op *openapi3.Operation) error,
 ) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
+		if IsWrapperChecker(next) {
+			return next
+		}
+
 		var withRoute rest.HandlerWithRoute
 
 		if HandlerAs(next, &withRoute) {

--- a/nethttp/openapi.go
+++ b/nethttp/openapi.go
@@ -11,6 +11,10 @@ import (
 // OpenAPIMiddleware reads info and adds validation to handler.
 func OpenAPIMiddleware(s *openapi.Collector) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
+		if IsWrapperChecker(h) {
+			return h
+		}
+
 		var (
 			withRoute rest.HandlerWithRoute
 			handler   *Handler

--- a/nethttp/usecase.go
+++ b/nethttp/usecase.go
@@ -10,6 +10,10 @@ import (
 // UseCaseMiddlewares applies use case middlewares to Handler.
 func UseCaseMiddlewares(mw ...usecase.Middleware) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
+		if IsWrapperChecker(handler) {
+			return handler
+		}
+
 		var uh *Handler
 		if !HandlerAs(handler, &uh) {
 			return handler

--- a/nethttp/wrapper.go
+++ b/nethttp/wrapper.go
@@ -15,6 +15,8 @@ func (*wrapperChecker) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
 func IsWrapperChecker(h http.Handler) bool {
 	if wm, ok := h.(*wrapperChecker); ok {
 		wm.found = true
+
+		return true
 	}
 
 	return false

--- a/nethttp/wrapper.go
+++ b/nethttp/wrapper.go
@@ -1,0 +1,30 @@
+package nethttp
+
+import "net/http"
+
+type wrapperChecker struct {
+	found bool
+}
+
+func (*wrapperChecker) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
+
+// IsWrapperChecker is a hack to mark middleware as a handler wrapper.
+// See chirouter.Wrapper Wrap() documentation for more details on the difference.
+//
+// Wrappers should invoke the check and do early return if it succeeds.
+func IsWrapperChecker(h http.Handler) bool {
+	if wm, ok := h.(*wrapperChecker); ok {
+		wm.found = true
+	}
+
+	return false
+}
+
+// MiddlewareIsWrapper is a hack to detect whether middleware is a handler wrapper.
+// See chirouter.Wrapper Wrap() documentation for more details on the difference.
+func MiddlewareIsWrapper(mw func(h http.Handler) http.Handler) bool {
+	wm := &wrapperChecker{}
+	mw(wm)
+
+	return wm.found
+}

--- a/nethttp/wrapper_test.go
+++ b/nethttp/wrapper_test.go
@@ -1,0 +1,26 @@
+package nethttp_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/swaggest/rest/nethttp"
+)
+
+func TestMiddlewareIsWrapper(t *testing.T) {
+	wrapper := func(handler http.Handler) http.Handler {
+		if nethttp.IsWrapperChecker(handler) {
+			return handler
+		}
+
+		return handler
+	}
+
+	notWrapper := func(handler http.Handler) http.Handler {
+		return handler
+	}
+
+	assert.True(t, nethttp.MiddlewareIsWrapper(wrapper))
+	assert.False(t, nethttp.MiddlewareIsWrapper(notWrapper))
+}

--- a/request/file_test.go
+++ b/request/file_test.go
@@ -41,12 +41,18 @@ func TestMapper_Decode_fileUploadTag(t *testing.T) {
 
 	decoderFactory.SetDecoderFunc(rest.ParamInPath, chirouter.PathToURLValues)
 
-	r.Wrap(
+	ws := []func(handler http.Handler) http.Handler{
 		nethttp.OpenAPIMiddleware(&apiSchema),
 		request.DecoderMiddleware(decoderFactory),
 		request.ValidatorMiddleware(validatorFactory),
 		response.EncoderMiddleware,
-	)
+	}
+
+	r.Wrap(ws...)
+
+	for i, w := range ws {
+		assert.True(t, nethttp.MiddlewareIsWrapper(w), i)
+	}
 
 	u := struct {
 		usecase.Interactor

--- a/request/middleware.go
+++ b/request/middleware.go
@@ -19,6 +19,10 @@ type requestMapping interface {
 // DecoderMiddleware sets up request decoder in suitable handlers.
 func DecoderMiddleware(factory DecoderMaker) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
+		if nethttp.IsWrapperChecker(handler) {
+			return handler
+		}
+
 		var (
 			withRoute          rest.HandlerWithRoute
 			withUseCase        rest.HandlerWithUseCase
@@ -57,6 +61,10 @@ type withRestHandler interface {
 // ValidatorMiddleware sets up request validator in suitable handlers.
 func ValidatorMiddleware(factory rest.RequestValidatorFactory) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
+		if nethttp.IsWrapperChecker(handler) {
+			return handler
+		}
+
 		var (
 			withRoute        rest.HandlerWithRoute
 			withUseCase      rest.HandlerWithUseCase

--- a/response/middleware.go
+++ b/response/middleware.go
@@ -14,6 +14,10 @@ type responseEncoderSetter interface {
 
 // EncoderMiddleware instruments qualifying http.Handler with Encoder.
 func EncoderMiddleware(handler http.Handler) http.Handler {
+	if nethttp.IsWrapperChecker(handler) {
+		return handler
+	}
+
 	var (
 		withUseCase        rest.HandlerWithUseCase
 		setResponseEncoder responseEncoderSetter

--- a/response/middleware_test.go
+++ b/response/middleware_test.go
@@ -38,8 +38,10 @@ func TestEncoderMiddleware(t *testing.T) {
 	r, err := http.NewRequest(http.MethodGet, "/", nil)
 	require.NoError(t, err)
 
-	response.EncoderMiddleware(h).ServeHTTP(w, r)
+	em := response.EncoderMiddleware
+	em(h).ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, `{"items":["one","two","three"]}`+"\n", w.Body.String())
 	assert.Equal(t, "Jane", w.Header().Get("X-Name"))
+	assert.True(t, nethttp.MiddlewareIsWrapper(em))
 }

--- a/response/validator.go
+++ b/response/validator.go
@@ -15,6 +15,10 @@ type withRestHandler interface {
 // ValidatorMiddleware sets up response validator in suitable handlers.
 func ValidatorMiddleware(factory rest.ResponseValidatorFactory) func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
+		if nethttp.IsWrapperChecker(handler) {
+			return handler
+		}
+
 		var (
 			withUseCase       rest.HandlerWithUseCase
 			handlerTrait      withRestHandler

--- a/response/validator_test.go
+++ b/response/validator_test.go
@@ -47,6 +47,8 @@ func TestValidatorMiddleware(t *testing.T) {
 	validatorFactory := jsonschema.NewFactory(apiSchema, apiSchema)
 	wh := nethttp.WrapHandler(h, response.EncoderMiddleware, response.ValidatorMiddleware(validatorFactory))
 
+	assert.True(t, nethttp.MiddlewareIsWrapper(response.ValidatorMiddleware(validatorFactory)))
+
 	w := httptest.NewRecorder()
 	r, err := http.NewRequest(http.MethodGet, "/", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #96.

Separation of `Wrap` and `Use`/`With` introduced in #76 led to an opposite limitation: wrappers that are configured in sub-routers have no effect as they are passed to the original `chi` router that does not know how to deal with them.

This PR implements a hacky compromise, that some middlewares in `Use`/`With` can be considered handler wrappers, but for that they need to exhibit particular indicative behavior.

Then wrappers would go to wrappers (not going to chi), and middlewares would go to chi (not going to wrappers).
