### PR TITLE
Fix handling of deeply embedded writer together with headers

### DIFF
--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -7,7 +7,7 @@ replace github.com/swaggest/rest => ../
 require (
 	github.com/bool64/ctxd v1.2.0
 	github.com/bool64/dev v0.2.22
-	github.com/bool64/httpmock v0.1.6
+	github.com/bool64/httpmock v0.1.7
 	github.com/bool64/httptestbench v0.1.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -37,7 +37,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v3 v3.1.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
-	github.com/swaggest/form/v5 v5.0.1 // indirect
+	github.com/swaggest/form/v5 v5.0.2 // indirect
 	github.com/swaggest/refl v1.1.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/vearutop/dynhist-go v1.1.0 // indirect

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -3,13 +3,12 @@ github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/bool64/ctxd v1.2.0 h1:x/ObTZswHT7TNJdQcPWw6YplnZ3oRyFZ+i+YqDb9Ib4=
 github.com/bool64/ctxd v1.2.0/go.mod h1:cSMhQNUcfu8XZRAUSrrFZhNd4DzK6LFN3DR5yeGW74o=
-github.com/bool64/dev v0.1.35/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.1.41/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.2.5/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.2.22 h1:YJFKBRKplkt+0Emq/5Xk1Z5QRmMNzc1UOJkR3rxJksA=
 github.com/bool64/dev v0.2.22/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
-github.com/bool64/httpmock v0.1.6 h1:v9+AmoSabaHuR7abjnhGwGxsaNljtFAYtluF0p4Q3ng=
-github.com/bool64/httpmock v0.1.6/go.mod h1:pQukYUfoG9gW4fRAv+xHuvA2BlRoauEXK/XG5mKD04I=
+github.com/bool64/httpmock v0.1.7 h1:w2LY/1N68AkwhY7ODDYs7DPJsgPO9W6rLLo9p/J70Rc=
+github.com/bool64/httpmock v0.1.7/go.mod h1:3T4cLULWI5qlTx+tSF6YaiAWq4IZ1aP//klpumgPj1s=
 github.com/bool64/httptestbench v0.1.4 h1:35f9RwWqcnQRXM+sA+GUhWVGSa6XEFlKpNSH9oYzOjI=
 github.com/bool64/httptestbench v0.1.4/go.mod h1:b9ItXGtscs9AcR5oUDnWCTLosQ/DCjiG4euDbHN8T40=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=
@@ -60,8 +59,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/swaggest/assertjson v1.7.0 h1:SKw5Rn0LQs6UvmGrIdaKQbMR1R3ncXm5KNon+QJ7jtw=
 github.com/swaggest/assertjson v1.7.0/go.mod h1:vxMJMehbSVJd+dDWFCKv3QRZKNTpy/ktZKTz9LOEDng=
-github.com/swaggest/form/v5 v5.0.1 h1:YQH0REX7iMKhtoVPWXREZgbt50VYXNCKK61psnD8Fgo=
-github.com/swaggest/form/v5 v5.0.1/go.mod h1:vdnaSTze7cxVKhWiCabrfm1YeLwWLpb9P941Gxv4FnA=
+github.com/swaggest/form/v5 v5.0.2 h1:TiimP7UX3q1nSI5ZGg6tGMmxg8UJB0JNpaZjXWH6V2E=
+github.com/swaggest/form/v5 v5.0.2/go.mod h1:Ayta1ggwSnDd4zwzv47jQL4RHk7WOTHp65nzwBc0IhU=
 github.com/swaggest/jsonschema-go v0.3.43 h1:qJcVuGs8RAsV4X4qmUd5mepEIwFHqLs9PkB1/DmvjYk=
 github.com/swaggest/jsonschema-go v0.3.43/go.mod h1:KOiJQorzO12Yj9+5HRCJsH7OcYaa5QjH4/IilA+8TQg=
 github.com/swaggest/openapi-go v0.2.26 h1:Sjx3wb0ndm4KcrveDTFHgN+Rt+W5X2WVTuFGHIyD22s=

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ go 1.17
 
 require (
 	github.com/bool64/dev v0.2.22
-	github.com/bool64/httpmock v0.1.6
+	github.com/bool64/httpmock v0.1.7
 	github.com/bool64/shared v0.1.5
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/santhosh-tekuri/jsonschema/v3 v3.1.0
 	github.com/stretchr/testify v1.8.1
 	github.com/swaggest/assertjson v1.7.0
-	github.com/swaggest/form/v5 v5.0.1
+	github.com/swaggest/form/v5 v5.0.2
 	github.com/swaggest/jsonschema-go v0.3.43
 	github.com/swaggest/openapi-go v0.2.26
 	github.com/swaggest/refl v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/bool64/dev v0.1.35/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.2.5/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.2.10/go.mod h1:/csLrm+4oDSsKJRIVS0mrywAonLnYKFG8RvGT7Jh9b8=
 github.com/bool64/dev v0.2.16/go.mod h1:/csLrm+4oDSsKJRIVS0mrywAonLnYKFG8RvGT7Jh9b8=
@@ -7,8 +6,8 @@ github.com/bool64/dev v0.2.20/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8
 github.com/bool64/dev v0.2.21/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/dev v0.2.22 h1:YJFKBRKplkt+0Emq/5Xk1Z5QRmMNzc1UOJkR3rxJksA=
 github.com/bool64/dev v0.2.22/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
-github.com/bool64/httpmock v0.1.6 h1:v9+AmoSabaHuR7abjnhGwGxsaNljtFAYtluF0p4Q3ng=
-github.com/bool64/httpmock v0.1.6/go.mod h1:pQukYUfoG9gW4fRAv+xHuvA2BlRoauEXK/XG5mKD04I=
+github.com/bool64/httpmock v0.1.7 h1:w2LY/1N68AkwhY7ODDYs7DPJsgPO9W6rLLo9p/J70Rc=
+github.com/bool64/httpmock v0.1.7/go.mod h1:3T4cLULWI5qlTx+tSF6YaiAWq4IZ1aP//klpumgPj1s=
 github.com/bool64/shared v0.1.4/go.mod h1:ryGjsnQFh6BnEXClfVlEJrzjwzat7CmA8PNS5E+jPp0=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=
 github.com/bool64/shared v0.1.5/go.mod h1:081yz68YC9jeFB3+Bbmno2RFWvGKv1lPKkMP6MHJlPs=
@@ -74,8 +73,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/swaggest/assertjson v1.7.0 h1:SKw5Rn0LQs6UvmGrIdaKQbMR1R3ncXm5KNon+QJ7jtw=
 github.com/swaggest/assertjson v1.7.0/go.mod h1:vxMJMehbSVJd+dDWFCKv3QRZKNTpy/ktZKTz9LOEDng=
-github.com/swaggest/form/v5 v5.0.1 h1:YQH0REX7iMKhtoVPWXREZgbt50VYXNCKK61psnD8Fgo=
-github.com/swaggest/form/v5 v5.0.1/go.mod h1:vdnaSTze7cxVKhWiCabrfm1YeLwWLpb9P941Gxv4FnA=
+github.com/swaggest/form/v5 v5.0.2 h1:TiimP7UX3q1nSI5ZGg6tGMmxg8UJB0JNpaZjXWH6V2E=
+github.com/swaggest/form/v5 v5.0.2/go.mod h1:Ayta1ggwSnDd4zwzv47jQL4RHk7WOTHp65nzwBc0IhU=
 github.com/swaggest/jsonschema-go v0.3.42/go.mod h1:yt5lcjdqywYtNnzkFgYnyfvMwlH2XHEDitKw749AV1w=
 github.com/swaggest/jsonschema-go v0.3.43 h1:qJcVuGs8RAsV4X4qmUd5mepEIwFHqLs9PkB1/DmvjYk=
 github.com/swaggest/jsonschema-go v0.3.43/go.mod h1:KOiJQorzO12Yj9+5HRCJsH7OcYaa5QjH4/IilA+8TQg=

--- a/resttest/client_test.go
+++ b/resttest/client_test.go
@@ -102,5 +102,5 @@ func TestNewClient_failedExpectation(t *testing.T) {
 
 	c.WithURI("/")
 	assert.EqualError(t, c.ExpectResponseBody([]byte(`{"foo":"bar}"`)),
-		"unexpected body, expected: {\"foo\":\"bar}\", received: {\"bar\":\"foo\"}")
+		"unexpected body, expected: \"{\\\"foo\\\":\\\"bar}\\\"\", received: \"{\\\"bar\\\":\\\"foo\\\"}\"")
 }


### PR DESCRIPTION
```go
type generateLinksOutput struct {
	usecase.OutputWithEmbeddedWriter

	ContentDisposition string `header:"Content-Disposition"`
}

// GenerateLinksForm creates use case interactor.
func GenerateLinksForm(base usecase.IOInteractorOf[generateLinksInput, generatedLinks]) usecase.Interactor {
	u := usecase.NewInteractor(func(ctx context.Context, in generateLinksFormInput, out *generateLinksOutput) error {
		out.ContentDisposition = "attachment; filename=\"links.csv\""
```

This would panic

```
 panic: reflect.Value.Interface: cannot return value obtained from unexported field or method
 
 -> reflect.valueInterface
 ->   /usr/local/opt/go/libexec/src/reflect/value.go:1489

    reflect.Value.Interface
      /usr/local/opt/go/libexec/src/reflect/value.go:1478
    github.com/swaggest/form/v5.(*encoder).setFieldByType
      /Users/vearutop/go/pkg/mod/github.com/swaggest/form/v5@v5.0.1/encoder.go:123
    github.com/swaggest/form/v5.(*encoder).traverseStruct
      /Users/vearutop/go/pkg/mod/github.com/swaggest/form/v5@v5.0.1/encoder.go:60
    github.com/swaggest/form/v5.(*encoder).setFieldByType
      /Users/vearutop/go/pkg/mod/github.com/swaggest/form/v5@v5.0.1/encoder.go:233
...
```