### PR TITLE
Added Execution Hooks around UseCase Interactor

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,8 @@ linters-settings:
     threshold: 100
   misspell:
     locale: US
+  nlreturn:
+    block-size: 2
   unused:
     check-exported: false
   unparam:

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ It can provide information about itself that will be exposed in generated docume
 
 ```go
 // Create use case interactor with references to input/output types and interaction function.
-u := usecase.NewIOI(new(helloInput), new(helloOutput), func(ctx context.Context, input, output interface{}) error {
+u := usecase.NewIOI(new(helloInput), new(helloOutput), func(ctx context.Context, input, output any) error {
     var (
         in  = input.(*helloInput)
         out = output.(*helloOutput)
@@ -220,7 +220,7 @@ u.SetTitle("Greeter")
 u.SetDescription("Greeter greets you.")
 u.Input = new(helloInput)
 u.Output = new(helloOutput)
-u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) error {
+u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) error {
     // Do something about input to prepare output.
     return nil
 })

--- a/_examples/advanced-generic/error_response.go
+++ b/_examples/advanced-generic/error_response.go
@@ -12,8 +12,8 @@ import (
 )
 
 type customErr struct {
-	Message string                 `json:"msg"`
-	Details map[string]interface{} `json:"details,omitempty"`
+	Message string         `json:"msg"`
+	Details map[string]any `json:"details,omitempty"`
 }
 
 func errorResponse() usecase.Interactor {

--- a/_examples/advanced-generic/output_headers_test.go
+++ b/_examples/advanced-generic/output_headers_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +42,7 @@ func Test_outputHeaders(t *testing.T) {
 
 	assert.Equal(t, resp.StatusCode, http.StatusOK)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
 

--- a/_examples/advanced-generic/output_writer.go
+++ b/_examples/advanced-generic/output_writer.go
@@ -16,7 +16,7 @@ func outputCSVWriter() usecase.Interactor {
 		usecase.OutputWithEmbeddedWriter
 	}
 
-	u := usecase.NewInteractor(func(ctx context.Context, _ interface{}, out *writerOutput) (err error) {
+	u := usecase.NewInteractor(func(ctx context.Context, _ any, out *writerOutput) (err error) {
 		out.Header = "abc"
 
 		c := csv.NewWriter(out)

--- a/_examples/advanced-generic/request_response_mapping_test.go
+++ b/_examples/advanced-generic/request_response_mapping_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -32,7 +33,7 @@ func Test_requestResponseMapping(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, "", string(body))

--- a/_examples/advanced-generic/router.go
+++ b/_examples/advanced-generic/router.go
@@ -71,7 +71,7 @@ func NewRouter() http.Handler {
 		func(handler http.Handler) http.Handler {
 			var h *nethttp.Handler
 			if nethttp.HandlerAs(handler, &h) {
-				h.MakeErrResp = func(ctx context.Context, err error) (int, interface{}) {
+				h.MakeErrResp = func(ctx context.Context, err error) (int, any) {
 					code, er := rest.Err(err)
 
 					var ae anotherErr

--- a/_examples/advanced/dummy.go
+++ b/_examples/advanced/dummy.go
@@ -7,7 +7,7 @@ import (
 )
 
 func dummy() usecase.Interactor {
-	return usecase.NewIOI(nil, nil, func(ctx context.Context, input, output interface{}) error {
+	return usecase.NewIOI(nil, nil, func(ctx context.Context, input, output any) error {
 		return nil
 	})
 }

--- a/_examples/advanced/error_response.go
+++ b/_examples/advanced/error_response.go
@@ -10,8 +10,8 @@ import (
 )
 
 type customErr struct {
-	Message string                 `json:"msg"`
-	Details map[string]interface{} `json:"details,omitempty"`
+	Message string         `json:"msg"`
+	Details map[string]any `json:"details,omitempty"`
 }
 
 func errorResponse() usecase.Interactor {
@@ -23,7 +23,7 @@ func errorResponse() usecase.Interactor {
 		Status string `json:"status"`
 	}
 
-	u := usecase.NewIOI(new(errType), new(okResp), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(errType), new(okResp), func(ctx context.Context, input, output any) (err error) {
 		var (
 			in  = input.(*errType)
 			out = output.(*okResp)

--- a/_examples/advanced/file_multi_upload.go
+++ b/_examples/advanced/file_multi_upload.go
@@ -26,7 +26,7 @@ func fileMultiUploader() usecase.Interactor {
 		Query        int                    `json:"inQuery"`
 	}
 
-	u := usecase.NewIOI(new(upload), new(info), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(upload), new(info), func(ctx context.Context, input, output any) (err error) {
 		var (
 			in  = input.(*upload)
 			out = output.(*info)

--- a/_examples/advanced/file_upload.go
+++ b/_examples/advanced/file_upload.go
@@ -26,7 +26,7 @@ func fileUploader() usecase.Interactor {
 		Query       int                  `json:"inQuery"`
 	}
 
-	u := usecase.NewIOI(new(upload), new(info), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(upload), new(info), func(ctx context.Context, input, output any) (err error) {
 		var (
 			in  = input.(*upload)
 			out = output.(*info)

--- a/_examples/advanced/gzip_pass_through.go
+++ b/_examples/advanced/gzip_pass_through.go
@@ -66,7 +66,7 @@ func directGzip() usecase.Interactor {
 	}
 
 	u := usecase.NewIOI(new(gzipPassThroughInput), new(gzipPassThroughOutput),
-		func(ctx context.Context, input, output interface{}) error {
+		func(ctx context.Context, input, output any) error {
 			var (
 				in  = input.(*gzipPassThroughInput)
 				out = output.(*gzipPassThroughOutput)

--- a/_examples/advanced/json_body.go
+++ b/_examples/advanced/json_body.go
@@ -29,7 +29,7 @@ func jsonBody() usecase.Interactor {
 	}
 
 	u := usecase.NewIOI(new(inputWithJSON), new(outputWithJSON),
-		func(ctx context.Context, input, output interface{}) (err error) {
+		func(ctx context.Context, input, output any) (err error) {
 			var (
 				in  = input.(*inputWithJSON)
 				out = output.(*outputWithJSON)

--- a/_examples/advanced/json_body_validation.go
+++ b/_examples/advanced/json_body_validation.go
@@ -34,7 +34,7 @@ func jsonBodyValidation() usecase.Interactor {
 	u.Input = new(inputWithJSON)
 	u.Output = new(outputWithJSON)
 
-	u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) (err error) {
+	u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) (err error) {
 		var (
 			in  = input.(*inputWithJSON)
 			out = output.(*outputWithJSON)

--- a/_examples/advanced/json_map_body.go
+++ b/_examples/advanced/json_map_body.go
@@ -26,7 +26,7 @@ func jsonMapBody() usecase.Interactor {
 		Data   JSONMapPayload `json:"data"`
 	}
 
-	u := usecase.NewIOI(new(jsonMapReq), new(jsonOutput), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(jsonMapReq), new(jsonOutput), func(ctx context.Context, input, output any) (err error) {
 		var (
 			in  = input.(*jsonMapReq)
 			out = output.(*jsonOutput)

--- a/_examples/advanced/json_param.go
+++ b/_examples/advanced/json_param.go
@@ -28,7 +28,7 @@ func jsonParam() usecase.Interactor {
 		JSONPayload
 	}
 
-	u := usecase.NewIOI(new(inputWithJSON), new(outputWithJSON), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(inputWithJSON), new(outputWithJSON), func(ctx context.Context, input, output any) (err error) {
 		var (
 			in  = input.(*inputWithJSON)
 			out = output.(*outputWithJSON)

--- a/_examples/advanced/json_slice_body.go
+++ b/_examples/advanced/json_slice_body.go
@@ -26,7 +26,7 @@ func jsonSliceBody() usecase.Interactor {
 		Data   JSONSlicePayload `json:"data"`
 	}
 
-	u := usecase.NewIOI(new(jsonSliceReq), new(jsonOutput), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(jsonSliceReq), new(jsonOutput), func(ctx context.Context, input, output any) (err error) {
 		var (
 			in  = input.(*jsonSliceReq)
 			out = output.(*jsonOutput)

--- a/_examples/advanced/no_validation.go
+++ b/_examples/advanced/no_validation.go
@@ -23,7 +23,7 @@ func noValidation() usecase.Interactor {
 		} `json:"data"`
 	}
 
-	u := usecase.NewIOI(new(inputPort), new(outputPort), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(inputPort), new(outputPort), func(ctx context.Context, input, output any) (err error) {
 		in := input.(*inputPort)
 		out := output.(*outputPort)
 

--- a/_examples/advanced/output_headers.go
+++ b/_examples/advanced/output_headers.go
@@ -23,7 +23,7 @@ func outputHeaders() usecase.Interactor {
 
 	u.Output = new(headerOutput)
 
-	u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) (err error) {
+	u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) (err error) {
 		out := output.(*headerOutput)
 
 		out.Header = "abc"

--- a/_examples/advanced/output_writer.go
+++ b/_examples/advanced/output_writer.go
@@ -26,7 +26,7 @@ func outputCSVWriter() usecase.Interactor {
 
 	u.Output = new(writerOutput)
 
-	u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) (err error) {
+	u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) (err error) {
 		out := output.(*writerOutput)
 
 		out.Header = "abc"

--- a/_examples/advanced/query_object.go
+++ b/_examples/advanced/query_object.go
@@ -16,7 +16,7 @@ func queryObject() usecase.Interactor {
 	}
 
 	u := usecase.NewIOI(new(inputQueryObject), new(outputQueryObject),
-		func(ctx context.Context, input, output interface{}) (err error) {
+		func(ctx context.Context, input, output any) (err error) {
 			var (
 				in  = input.(*inputQueryObject)
 				out = output.(*outputQueryObject)

--- a/_examples/advanced/request_response_mapping.go
+++ b/_examples/advanced/request_response_mapping.go
@@ -17,7 +17,7 @@ func reqRespMapping() usecase.Interactor {
 		Val2 int    `json:"-" description:"Simple scalar value with sample validation." required:"true" minimum:"3"`
 	}
 
-	u := usecase.NewIOI(new(inputPort), new(outputPort), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(inputPort), new(outputPort), func(ctx context.Context, input, output any) (err error) {
 		var (
 			in  = input.(*inputPort)
 			out = output.(*outputPort)

--- a/_examples/advanced/request_response_mapping_test.go
+++ b/_examples/advanced/request_response_mapping_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +31,7 @@ func Test_requestResponseMapping(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, "", string(body))

--- a/_examples/advanced/router.go
+++ b/_examples/advanced/router.go
@@ -69,7 +69,7 @@ func NewRouter() http.Handler {
 		func(handler http.Handler) http.Handler {
 			var h *nethttp.Handler
 			if nethttp.HandlerAs(handler, &h) {
-				h.MakeErrResp = func(ctx context.Context, err error) (int, interface{}) {
+				h.MakeErrResp = func(ctx context.Context, err error) (int, any) {
 					code, er := rest.Err(err)
 
 					var ae anotherErr

--- a/_examples/advanced/validation.go
+++ b/_examples/advanced/validation.go
@@ -23,7 +23,7 @@ func validation() usecase.Interactor {
 		} `json:"data" required:"true"`
 	}
 
-	u := usecase.NewIOI(new(inputPort), new(outputPort), func(ctx context.Context, input, output interface{}) (err error) {
+	u := usecase.NewIOI(new(inputPort), new(outputPort), func(ctx context.Context, input, output any) (err error) {
 		in := input.(*inputPort)
 		out := output.(*outputPort)
 

--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	// Create use case interactor with references to input/output types and interaction function.
-	u := usecase.NewIOI(new(helloInput), new(helloOutput), func(ctx context.Context, input, output interface{}) error {
+	u := usecase.NewIOI(new(helloInput), new(helloOutput), func(ctx context.Context, input, output any) error {
 		var (
 			in  = input.(*helloInput)
 			out = output.(*helloOutput)

--- a/_examples/task-api/internal/infra/log/usecase.go
+++ b/_examples/task-api/internal/infra/log/usecase.go
@@ -25,7 +25,7 @@ func UseCaseMiddleware() usecase.Middleware {
 			name = hasName.Name()
 		}
 
-		return usecase.Interact(func(ctx context.Context, input, output interface{}) error {
+		return usecase.Interact(func(ctx context.Context, input, output any) error {
 			err := next.Interact(ctx, input, output)
 			if err != nil {
 				log.Printf("usecase %s request (%v) failed: %v", name, input, err)

--- a/_examples/task-api/internal/infra/repository/task.go
+++ b/_examples/task-api/internal/infra/repository/task.go
@@ -130,7 +130,7 @@ func (tr *Task) Create(ctx context.Context, value task.Value) (task.Entity, erro
 		if t.Value.Goal == value.Goal {
 			return task.Entity{}, usecase.Error{
 				StatusCode: status.AlreadyExists,
-				Context: map[string]interface{}{
+				Context: map[string]any{
 					"task": t,
 				},
 				Value: errors.New("task with same goal already exists"),

--- a/_examples/task-api/internal/usecase/create_task.go
+++ b/_examples/task-api/internal/usecase/create_task.go
@@ -15,7 +15,7 @@ func CreateTask(
 		TaskCreator() task.Creator
 	},
 ) usecase.IOInteractor {
-	u := usecase.NewIOI(new(task.Value), new(task.Entity), func(ctx context.Context, input, output interface{}) error {
+	u := usecase.NewIOI(new(task.Value), new(task.Entity), func(ctx context.Context, input, output any) error {
 		var (
 			in  = input.(*task.Value)
 			out = output.(*task.Entity)

--- a/_examples/task-api/internal/usecase/find_task.go
+++ b/_examples/task-api/internal/usecase/find_task.go
@@ -15,7 +15,7 @@ func FindTask(
 	},
 ) usecase.IOInteractor {
 	u := usecase.NewIOI(new(task.Identity), new(task.Entity),
-		func(ctx context.Context, input, output interface{}) error {
+		func(ctx context.Context, input, output any) error {
 			var (
 				in  = input.(*task.Identity)
 				out = output.(*task.Entity)

--- a/_examples/task-api/internal/usecase/find_tasks.go
+++ b/_examples/task-api/internal/usecase/find_tasks.go
@@ -15,7 +15,7 @@ func FindTasks(
 		TaskFinder() task.Finder
 	},
 ) usecase.IOInteractor {
-	u := usecase.NewIOI(nil, new([]task.Entity), func(ctx context.Context, input, output interface{}) error {
+	u := usecase.NewIOI(nil, new([]task.Entity), func(ctx context.Context, input, output any) error {
 		out, ok := output.(*[]task.Entity)
 		if !ok {
 			return fmt.Errorf("%w: unexpected output type %T", status.Unimplemented, output)

--- a/_examples/task-api/internal/usecase/finish_task.go
+++ b/_examples/task-api/internal/usecase/finish_task.go
@@ -14,7 +14,7 @@ type finishTaskDeps interface {
 
 // FinishTask creates usecase interactor.
 func FinishTask(deps finishTaskDeps) usecase.IOInteractor {
-	u := usecase.NewIOI(new(task.Identity), nil, func(ctx context.Context, input, _ interface{}) error {
+	u := usecase.NewIOI(new(task.Identity), nil, func(ctx context.Context, input, _ any) error {
 		var (
 			in  = input.(*task.Identity)
 			err error

--- a/_examples/task-api/internal/usecase/update_task.go
+++ b/_examples/task-api/internal/usecase/update_task.go
@@ -19,7 +19,7 @@ func UpdateTask(
 		TaskUpdater() task.Updater
 	},
 ) usecase.Interactor {
-	u := usecase.NewIOI(new(updateTask), nil, func(ctx context.Context, input, _ interface{}) error {
+	u := usecase.NewIOI(new(updateTask), nil, func(ctx context.Context, input, _ any) error {
 		var (
 			in  = input.(*updateTask)
 			err error

--- a/chirouter/wrapper_test.go
+++ b/chirouter/wrapper_test.go
@@ -272,7 +272,7 @@ func TestWrapper_Mount(t *testing.T) {
 		nethttp.HTTPBasicSecurityMiddleware(service.OpenAPICollector, "Admin", "Admin access"),
 	)
 
-	apiV1.Post("/sum", usecase.NewIOI(new([]int), new(int), func(ctx context.Context, input, output interface{}) error {
+	apiV1.Post("/sum", usecase.NewIOI(new([]int), new(int), func(ctx context.Context, input, output any) error {
 		return errors.New("oops")
 	}))
 

--- a/error.go
+++ b/error.go
@@ -16,7 +16,7 @@ type ErrWithHTTPStatus interface {
 // ErrWithFields exposes structured context of error.
 type ErrWithFields interface {
 	error
-	Fields() map[string]interface{}
+	Fields() map[string]any
 }
 
 // ErrWithAppCode exposes application error code.
@@ -81,10 +81,10 @@ func Err(err error) (int, ErrResponse) {
 
 // ErrResponse is HTTP error response body.
 type ErrResponse struct {
-	StatusText string                 `json:"status,omitempty" description:"Status text."`
-	AppCode    int                    `json:"code,omitempty" description:"Application-specific error code."`
-	ErrorText  string                 `json:"error,omitempty" description:"Error message."`
-	Context    map[string]interface{} `json:"context,omitempty" description:"Application context."`
+	StatusText string         `json:"status,omitempty"  description:"Status text."`
+	AppCode    int            `json:"code,omitempty"    description:"Application-specific error code."`
+	ErrorText  string         `json:"error,omitempty"   description:"Error message."`
+	Context    map[string]any `json:"context,omitempty" description:"Application context."`
 
 	err            error // Original error.
 	httpStatusCode int   // HTTP response status code.

--- a/error_test.go
+++ b/error_test.go
@@ -34,12 +34,12 @@ func TestErr(t *testing.T) {
 	err := usecase.Error{
 		StatusCode: status.InvalidArgument,
 		Value:      errors.New("failed"),
-		Context:    map[string]interface{}{"hello": "world"},
+		Context:    map[string]any{"hello": "world"},
 	}
 	code, er := rest.Err(err)
 
 	assert.Equal(t, http.StatusBadRequest, code)
-	assert.Equal(t, map[string]interface{}{"hello": "world"}, er.Context)
+	assert.Equal(t, map[string]any{"hello": "world"}, er.Context)
 	assert.Equal(t, "invalid argument: failed", er.Error())
 	assert.Equal(t, "INVALID_ARGUMENT", er.StatusText)
 	assert.Equal(t, 0, er.AppCode)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/swaggest/rest
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bool64/dev v0.2.22

--- a/gzip/container_test.go
+++ b/gzip/container_test.go
@@ -46,11 +46,11 @@ func TestWriteJSON(t *testing.T) {
 		usecase.WithOutput
 	}{}
 
-	var ur interface{} = cont
+	var ur any = cont
 
-	u.Output = new(interface{})
-	u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) error {
-		*output.(*interface{}) = ur
+	u.Output = new(any)
+	u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) error {
+		*output.(*any) = ur
 
 		return nil
 	})

--- a/jsonschema/validator.go
+++ b/jsonschema/validator.go
@@ -15,7 +15,7 @@ var _ rest.Validator = &Validator{}
 // Validator is a JSON Schema based validator.
 type Validator struct {
 	// JSONMarshal controls custom marshaler, nil value enables "encoding/json".
-	JSONMarshal func(interface{}) ([]byte, error)
+	JSONMarshal func(any) ([]byte, error)
 
 	inNamedSchemas map[rest.ParamIn]map[string]*jsonschema.Schema
 	inRequired     map[rest.ParamIn][]string
@@ -38,7 +38,7 @@ func NewFactory(
 // Please use NewFactory to create an instance.
 type Factory struct {
 	// JSONMarshal controls custom marshaler, nil value enables "encoding/json".
-	JSONMarshal func(interface{}) ([]byte, error)
+	JSONMarshal func(any) ([]byte, error)
 
 	requestSchemas  rest.RequestJSONSchemaProvider
 	responseSchemas rest.ResponseJSONSchemaProvider
@@ -47,7 +47,7 @@ type Factory struct {
 // MakeRequestValidator creates request validator for HTTP method and input structure.
 func (f Factory) MakeRequestValidator(
 	method string,
-	input interface{},
+	input any,
 	mapping rest.RequestMapping,
 ) rest.Validator {
 	v := Validator{
@@ -68,7 +68,7 @@ func (f Factory) MakeRequestValidator(
 func (f Factory) MakeResponseValidator(
 	statusCode int,
 	contentType string,
-	output interface{},
+	output any,
 	headerMapping map[string]string,
 ) rest.Validator {
 	v := Validator{
@@ -139,7 +139,7 @@ func (v *Validator) AddSchema(in rest.ParamIn, name string, jsonSchema []byte, r
 	return nil
 }
 
-func (v *Validator) checkRequired(in rest.ParamIn, namedData map[string]interface{}) []string {
+func (v *Validator) checkRequired(in rest.ParamIn, namedData map[string]any) []string {
 	required := v.inRequired[in]
 
 	if len(required) == 0 {
@@ -189,7 +189,7 @@ func (v *Validator) HasConstraints(in rest.ParamIn) bool {
 }
 
 // ValidateData performs validation of a mapped request data.
-func (v *Validator) ValidateData(in rest.ParamIn, namedData map[string]interface{}) error {
+func (v *Validator) ValidateData(in rest.ParamIn, namedData map[string]any) error {
 	var errs rest.ValidationErrors
 
 	missing := v.checkRequired(in, namedData)

--- a/jsonschema/validator_test.go
+++ b/jsonschema/validator_test.go
@@ -24,7 +24,7 @@ func BenchmarkRequestValidator_ValidateRequestData(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	value := map[string]interface{}{
+	value := map[string]any{
 		"in_cookie": "abc",
 	}
 
@@ -47,27 +47,27 @@ func TestRequestValidator_ValidateData(t *testing.T) {
 			rest.ParamInFormData: map[string]string{"FormData": "inFormData"},
 		})
 
-	err := validator.ValidateData(rest.ParamInCookie, map[string]interface{}{"in_cookie": 123})
+	err := validator.ValidateData(rest.ParamInCookie, map[string]any{"in_cookie": 123})
 	assert.Equal(t, err, rest.ValidationErrors{"cookie:in_cookie": []string{"#: expected string, but got number"}})
 
-	err = validator.ValidateData(rest.ParamInCookie, map[string]interface{}{})
+	err = validator.ValidateData(rest.ParamInCookie, map[string]any{})
 	assert.Equal(t, err, rest.ValidationErrors{"cookie:in_cookie": []string{"missing value"}})
 
-	err = validator.ValidateData(rest.ParamInQuery, map[string]interface{}{"in_query": 123})
+	err = validator.ValidateData(rest.ParamInQuery, map[string]any{"in_query": 123})
 	assert.Equal(t, err, rest.ValidationErrors{"query:in_query": []string{"#: expected string, but got number"}})
 
-	err = validator.ValidateData(rest.ParamInQuery, map[string]interface{}{"in_query": "ab"})
+	err = validator.ValidateData(rest.ParamInQuery, map[string]any{"in_query": "ab"})
 	assert.Equal(t, err, rest.ValidationErrors{"query:in_query": []string{"#: length must be >= 3, but got 2"}})
 
-	assert.NoError(t, validator.ValidateData(rest.ParamInQuery, map[string]interface{}{}))
-	assert.NoError(t, validator.ValidateData(rest.ParamInQuery, map[string]interface{}{"unknown": 123}))
-	assert.NoError(t, validator.ValidateData(rest.ParamInQuery, map[string]interface{}{"in_query_ignored": 123}))
-	assert.NoError(t, validator.ValidateData("unknown", map[string]interface{}{}))
-	assert.NoError(t, validator.ValidateData(rest.ParamInCookie, map[string]interface{}{"in_cookie": "abc"}))
+	assert.NoError(t, validator.ValidateData(rest.ParamInQuery, map[string]any{}))
+	assert.NoError(t, validator.ValidateData(rest.ParamInQuery, map[string]any{"unknown": 123}))
+	assert.NoError(t, validator.ValidateData(rest.ParamInQuery, map[string]any{"in_query_ignored": 123}))
+	assert.NoError(t, validator.ValidateData("unknown", map[string]any{}))
+	assert.NoError(t, validator.ValidateData(rest.ParamInCookie, map[string]any{"in_cookie": "abc"}))
 
-	assert.NoError(t, validator.ValidateData(rest.ParamInFormData, map[string]interface{}{"inFormData": "abc"}))
+	assert.NoError(t, validator.ValidateData(rest.ParamInFormData, map[string]any{"inFormData": "abc"}))
 
-	err = validator.ValidateData(rest.ParamInFormData, map[string]interface{}{"inFormData": "ab"})
+	err = validator.ValidateData(rest.ParamInFormData, map[string]any{"inFormData": "ab"})
 	assert.Equal(t, err, rest.ValidationErrors{"formData:inFormData": []string{"#: length must be >= 3, but got 2"}})
 }
 
@@ -82,21 +82,21 @@ func TestFactory_MakeResponseValidator(t *testing.T) {
 
 	assert.NoError(t, validator.ValidateJSONBody([]byte(`{"name":"John"}`)))
 	assert.Error(t, validator.ValidateJSONBody([]byte(`{"name":""}`))) // minLength:"1" violated.
-	assert.NoError(t, validator.ValidateData(rest.ParamInHeader, map[string]interface{}{
+	assert.NoError(t, validator.ValidateData(rest.ParamInHeader, map[string]any{
 		"X-Trace": "abc",
 	}))
-	assert.Error(t, validator.ValidateData(rest.ParamInHeader, map[string]interface{}{
+	assert.Error(t, validator.ValidateData(rest.ParamInHeader, map[string]any{
 		"X-Trace": "abcd", // maxLength:"3" violated.
 	}))
 }
 
 func TestNullableTime(t *testing.T) {
-	type request struct {
+	type req struct {
 		ExpiryDate *time.Time `json:"expiryDate"`
 	}
 
 	validator := jsonschema.NewFactory(&openapi.Collector{}, &openapi.Collector{}).
-		MakeRequestValidator(http.MethodPost, new(request), nil)
+		MakeRequestValidator(http.MethodPost, new(req), nil)
 	err := validator.ValidateJSONBody([]byte(`{"expiryDate":null}`))
 
 	assert.NoError(t, err, "%+v", err)

--- a/nethttp/example_test.go
+++ b/nethttp/example_test.go
@@ -47,7 +47,7 @@ func ExampleSecurityMiddleware() {
 		},
 	})
 
-	u := usecase.NewIOI(nil, nil, func(ctx context.Context, input, output interface{}) error {
+	u := usecase.NewIOI(nil, nil, func(ctx context.Context, input, output any) error {
 		// Do something.
 		return nil
 	})

--- a/nethttp/openapi.go
+++ b/nethttp/openapi.go
@@ -129,7 +129,7 @@ func AnnotateOpenAPI(
 }
 
 // SecurityResponse is a security middleware option to customize response structure and status.
-func SecurityResponse(structure interface{}, httpStatus int) func(config *MiddlewareConfig) {
+func SecurityResponse(structure any, httpStatus int) func(config *MiddlewareConfig) {
 	return func(config *MiddlewareConfig) {
 		config.ResponseStructure = structure
 		config.ResponseStatus = httpStatus
@@ -139,7 +139,7 @@ func SecurityResponse(structure interface{}, httpStatus int) func(config *Middle
 // MiddlewareConfig defines security middleware options.
 type MiddlewareConfig struct {
 	// ResponseStructure declares structure that is used for unauthorized message, default rest.ErrResponse{}.
-	ResponseStructure interface{}
+	ResponseStructure any
 
 	// ResponseStatus declares HTTP status code that is used for unauthorized message, default http.StatusUnauthorized.
 	ResponseStatus int

--- a/nethttp/openapi_test.go
+++ b/nethttp/openapi_test.go
@@ -26,7 +26,7 @@ func TestOpenAPIMiddleware(t *testing.T) {
 		Value  string `json:"val"`
 		Header int
 	})
-	u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) error {
+	u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) error {
 		in, ok := input.(*Input)
 		assert.True(t, ok)
 		assert.Equal(t, 123, in.ID)

--- a/nethttp/options.go
+++ b/nethttp/options.go
@@ -50,7 +50,7 @@ func SuccessStatus(status int) func(h *Handler) {
 // RequestMapping creates rest.RequestMapping from struct tags.
 //
 // This can be used to decouple mapping from usecase input with additional struct.
-func RequestMapping(v interface{}) func(h *Handler) {
+func RequestMapping(v any) func(h *Handler) {
 	return func(h *Handler) {
 		m := make(rest.RequestMapping)
 
@@ -81,7 +81,7 @@ func RequestMapping(v interface{}) func(h *Handler) {
 // ResponseHeaderMapping creates headers mapping from struct tags.
 //
 // This can be used to decouple mapping from usecase input with additional struct.
-func ResponseHeaderMapping(v interface{}) func(h *Handler) {
+func ResponseHeaderMapping(v any) func(h *Handler) {
 	return func(h *Handler) {
 		if mm, ok := v.(map[string]string); ok {
 			h.RespHeaderMapping = mm

--- a/nethttp/usecase.go
+++ b/nethttp/usecase.go
@@ -21,7 +21,7 @@ func UseCaseMiddlewares(mw ...usecase.Middleware) func(http.Handler) http.Handle
 
 		u := uh.UseCase()
 		fu := usecase.Wrap(u, usecase.MiddlewareFunc(func(next usecase.Interactor) usecase.Interactor {
-			return usecase.Interact(func(ctx context.Context, input, output interface{}) error {
+			return usecase.Interact(func(ctx context.Context, input, output any) error {
 				return ctx.Value(decodeErrCtxKey{}).(error)
 			})
 		}))

--- a/nethttp/wrap.go
+++ b/nethttp/wrap.go
@@ -36,7 +36,7 @@ func WrapHandler(h http.Handler, mw ...func(http.Handler) http.Handler) http.Han
 //
 // HandlerAs will panic if target is not a non-nil pointer to either a type that implements
 // http.Handler, or to any interface type.
-func HandlerAs(handler http.Handler, target interface{}) bool {
+func HandlerAs(handler http.Handler, target any) bool {
 	if target == nil {
 		panic("target cannot be nil")
 	}

--- a/openapi/collector.go
+++ b/openapi/collector.go
@@ -249,7 +249,7 @@ func (c *Collector) processUseCase(op *openapi3.Operation, u usecase.Interactor,
 
 func (c *Collector) processExpectedErrors(op *openapi3.Operation, u usecase.Interactor, h rest.HandlerTrait) error {
 	var (
-		errsByCode        = map[int][]interface{}{}
+		errsByCode        = map[int][]any{}
 		statusCodes       []int
 		hasExpectedErrors usecase.HasExpectedErrors
 	)
@@ -260,7 +260,7 @@ func (c *Collector) processExpectedErrors(op *openapi3.Operation, u usecase.Inte
 
 	for _, e := range hasExpectedErrors.ExpectedErrors() {
 		var (
-			errResp    interface{}
+			errResp    any
 			statusCode int
 		)
 
@@ -362,7 +362,7 @@ func (c *Collector) provideParametersJSONSchemas(op openapi3.Operation, validato
 // ProvideRequestJSONSchemas provides JSON Schemas for request structure.
 func (c *Collector) ProvideRequestJSONSchemas(
 	method string,
-	input interface{},
+	input any,
 	mapping rest.RequestMapping,
 	validator rest.JSONSchemaValidator,
 ) error {
@@ -490,7 +490,7 @@ func (c *Collector) provideHeaderSchemas(resp *openapi3.Response, validator rest
 func (c *Collector) ProvideResponseJSONSchemas(
 	statusCode int,
 	contentType string,
-	output interface{},
+	output any,
 	headerMapping map[string]string,
 	validator rest.JSONSchemaValidator,
 ) error {

--- a/openapi/collector_test.go
+++ b/openapi/collector_test.go
@@ -25,13 +25,13 @@ import (
 var _ rest.JSONSchemaValidator = validatorMock{}
 
 type validatorMock struct {
-	ValidateDataFunc     func(in rest.ParamIn, namedData map[string]interface{}) error
+	ValidateDataFunc     func(in rest.ParamIn, namedData map[string]any) error
 	ValidateJSONBodyFunc func(jsonBody []byte) error
 	HasConstraintsFunc   func(in rest.ParamIn) bool
 	AddSchemaFunc        func(in rest.ParamIn, name string, schemaData []byte, required bool) error
 }
 
-func (v validatorMock) ValidateData(in rest.ParamIn, namedData map[string]interface{}) error {
+func (v validatorMock) ValidateData(in rest.ParamIn, namedData map[string]any) error {
 	return v.ValidateDataFunc(in, namedData)
 }
 
@@ -250,7 +250,7 @@ func TestCollector_Collect_CombineErrors(t *testing.T) {
 	u.SetExpectedErrors(status.InvalidArgument, anotherErr{}, status.FailedPrecondition, status.AlreadyExists)
 
 	h := rest.HandlerTrait{}
-	h.MakeErrResp = func(ctx context.Context, err error) (int, interface{}) {
+	h.MakeErrResp = func(ctx context.Context, err error) (int, any) {
 		code, er := rest.Err(err)
 
 		var ae anotherErr

--- a/request.go
+++ b/request.go
@@ -45,8 +45,8 @@ func (re RequestErrors) Error() string {
 }
 
 // Fields returns request errors by field location and name.
-func (re RequestErrors) Fields() map[string]interface{} {
-	res := make(map[string]interface{}, len(re))
+func (re RequestErrors) Fields() map[string]any {
+	res := make(map[string]any, len(re))
 
 	for k, v := range re {
 		res[k] = v

--- a/request/decoder.go
+++ b/request/decoder.go
@@ -19,11 +19,11 @@ type (
 	}
 
 	decoderFunc      func(r *http.Request) (url.Values, error)
-	valueDecoderFunc func(r *http.Request, v interface{}, validator rest.Validator) error
+	valueDecoderFunc func(r *http.Request, v any, validator rest.Validator) error
 )
 
-func decodeValidate(d *form.Decoder, v interface{}, p url.Values, in rest.ParamIn, val rest.Validator) error {
-	goValues := make(map[string]interface{}, len(p))
+func decodeValidate(d *form.Decoder, v any, p url.Values, in rest.ParamIn, val rest.Validator) error {
+	goValues := make(map[string]any, len(p))
 
 	err := d.Decode(v, p, goValues)
 	if err != nil {
@@ -50,7 +50,7 @@ func decodeValidate(d *form.Decoder, v interface{}, p url.Values, in rest.ParamI
 }
 
 func makeDecoder(in rest.ParamIn, formDecoder *form.Decoder, decoderFunc decoderFunc) valueDecoderFunc {
-	return func(r *http.Request, v interface{}, validator rest.Validator) error {
+	return func(r *http.Request, v any, validator rest.Validator) error {
 		values, err := decoderFunc(r)
 		if err != nil {
 			return err
@@ -73,7 +73,7 @@ type decoder struct {
 var _ nethttp.RequestDecoder = &decoder{}
 
 // Decode populates and validates input with data from http request.
-func (d *decoder) Decode(r *http.Request, input interface{}, validator rest.Validator) error {
+func (d *decoder) Decode(r *http.Request, input any, validator rest.Validator) error {
 	if i, ok := input.(Loader); ok {
 		return i.LoadFromHTTPRequest(r)
 	}

--- a/request/file.go
+++ b/request/file.go
@@ -17,7 +17,7 @@ var (
 	multipartFileHeadersType = reflect.TypeOf(([]*multipart.FileHeader)(nil))
 )
 
-func decodeFiles(r *http.Request, input interface{}, _ rest.Validator) error {
+func decodeFiles(r *http.Request, input any, _ rest.Validator) error {
 	v := reflect.ValueOf(input)
 
 	return decodeFilesInStruct(r, v)

--- a/request/file_test.go
+++ b/request/file_test.go
@@ -3,7 +3,7 @@ package request_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -60,14 +60,14 @@ func TestMapper_Decode_fileUploadTag(t *testing.T) {
 	}{}
 
 	u.Input = new(fileReqTest)
-	u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) error {
+	u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) error {
 		in, ok := input.(*fileReqTest)
 		assert.True(t, ok)
 		assert.NotNil(t, in.Upload)
 		assert.NotNil(t, in.UploadHeader)
 		assert.Equal(t, "my.csv", in.UploadHeader.Filename)
 		assert.Equal(t, int64(6), in.UploadHeader.Size)
-		content, err := ioutil.ReadAll(in.Upload)
+		content, err := io.ReadAll(in.Upload)
 		assert.NoError(t, err)
 		assert.NoError(t, in.Upload.Close())
 		assert.Equal(t, "Hello!", string(content))
@@ -79,12 +79,12 @@ func TestMapper_Decode_fileUploadTag(t *testing.T) {
 		assert.Equal(t, "my2.csv", in.UploadsHeaders[1].Filename)
 		assert.Equal(t, int64(7), in.UploadsHeaders[1].Size)
 
-		content, err = ioutil.ReadAll(in.Uploads[0])
+		content, err = io.ReadAll(in.Uploads[0])
 		assert.NoError(t, err)
 		assert.NoError(t, in.Uploads[0].Close())
 		assert.Equal(t, "Hello1!", string(content))
 
-		content, err = ioutil.ReadAll(in.Uploads[1])
+		content, err = io.ReadAll(in.Uploads[1])
 		assert.NoError(t, err)
 		assert.NoError(t, in.Uploads[1].Close())
 		assert.Equal(t, "Hello2!", string(content))

--- a/request/jsonbody.go
+++ b/request/jsonbody.go
@@ -12,19 +12,19 @@ import (
 )
 
 var bufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return bytes.NewBuffer(nil)
 	},
 }
 
-func readJSON(rd io.Reader, v interface{}) error {
+func readJSON(rd io.Reader, v any) error {
 	d := json.NewDecoder(rd)
 
 	return d.Decode(v)
 }
 
-func decodeJSONBody(readJSON func(rd io.Reader, v interface{}) error, tolerateFormData bool) valueDecoderFunc {
-	return func(r *http.Request, input interface{}, validator rest.Validator) error {
+func decodeJSONBody(readJSON func(rd io.Reader, v any) error, tolerateFormData bool) valueDecoderFunc {
+	return func(r *http.Request, input any, validator rest.Validator) error {
 		if r.ContentLength == 0 {
 			return ErrMissingRequestBody
 		}

--- a/request/jsonbody_test.go
+++ b/request/jsonbody_test.go
@@ -30,7 +30,7 @@ func Test_decodeJSONBody(t *testing.T) {
 	assert.Equal(t, "248df4b7-aa70-47b8-a036-33ac447e668d", i.CustomerID)
 	assert.Equal(t, "withdraw", i.Type)
 
-	vl := rest.ValidatorFunc(func(in rest.ParamIn, namedData map[string]interface{}) error {
+	vl := rest.ValidatorFunc(func(in rest.ParamIn, namedData map[string]any) error {
 		return nil
 	})
 
@@ -90,7 +90,7 @@ func Test_decodeJSONBody_validateFailed(t *testing.T) {
 
 	var i []int
 
-	vl := rest.ValidatorFunc(func(in rest.ParamIn, namedData map[string]interface{}) error {
+	vl := rest.ValidatorFunc(func(in rest.ParamIn, namedData map[string]any) error {
 		return errors.New("failed")
 	})
 

--- a/request/middleware.go
+++ b/request/middleware.go
@@ -91,14 +91,14 @@ func ValidatorMiddleware(factory rest.RequestValidatorFactory) func(http.Handler
 var _ nethttp.RequestDecoder = DecoderFunc(nil)
 
 // DecoderFunc implements RequestDecoder with a func.
-type DecoderFunc func(r *http.Request, input interface{}, validator rest.Validator) error
+type DecoderFunc func(r *http.Request, input any, validator rest.Validator) error
 
 // Decode implements RequestDecoder.
-func (df DecoderFunc) Decode(r *http.Request, input interface{}, validator rest.Validator) error {
+func (df DecoderFunc) Decode(r *http.Request, input any, validator rest.Validator) error {
 	return df(r, input, validator)
 }
 
 // DecoderMaker creates request decoder for particular structured Go input value.
 type DecoderMaker interface {
-	MakeDecoder(method string, input interface{}, customMapping rest.RequestMapping) nethttp.RequestDecoder
+	MakeDecoder(method string, input any, customMapping rest.RequestMapping) nethttp.RequestDecoder
 }

--- a/request/reflect.go
+++ b/request/reflect.go
@@ -7,7 +7,7 @@ import (
 )
 
 // HasFileFields checks if the structure has fields to receive uploaded files.
-func hasFileFields(i interface{}, tagname string) bool {
+func hasFileFields(i any, tagname string) bool {
 	found := false
 
 	refl.WalkTaggedFields(reflect.ValueOf(i), func(v reflect.Value, sf reflect.StructField, tag string) {

--- a/request_test.go
+++ b/request_test.go
@@ -13,5 +13,5 @@ func TestRequestErrors_Error(t *testing.T) {
 	}
 
 	assert.EqualError(t, err, "bad request")
-	assert.Equal(t, map[string]interface{}{"foo": []string{"bar"}}, err.Fields())
+	assert.Equal(t, map[string]any{"foo": []string{"bar"}}, err.Fields())
 }

--- a/response/gzip/middleware_test.go
+++ b/response/gzip/middleware_test.go
@@ -3,7 +3,7 @@ package gzip_test
 import (
 	"bytes"
 	gz "compress/gzip"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -242,7 +242,7 @@ func gzipDecode(t *testing.T, data []byte) []byte {
 	r, err := gz.NewReader(b)
 	require.NoError(t, err)
 
-	j, err := ioutil.ReadAll(r)
+	j, err := io.ReadAll(r)
 	require.NoError(t, err)
 
 	require.NoError(t, r.Close())

--- a/response/middleware_test.go
+++ b/response/middleware_test.go
@@ -25,7 +25,7 @@ func TestEncoderMiddleware(t *testing.T) {
 	}
 
 	u.Output = new(outputPort)
-	u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) error {
+	u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) error {
 		output.(*outputPort).Name = "Jane"
 		output.(*outputPort).Items = []string{"one", "two", "three"}
 

--- a/response/validator_test.go
+++ b/response/validator_test.go
@@ -32,7 +32,7 @@ func TestValidatorMiddleware(t *testing.T) {
 	}
 
 	u.Output = new(outputPort)
-	u.Interactor = usecase.Interact(func(ctx context.Context, input, output interface{}) error {
+	u.Interactor = usecase.Interact(func(ctx context.Context, input, output any) error {
 		out, ok := output.(*outputPort)
 		require.True(t, ok)
 

--- a/resttest/client_test.go
+++ b/resttest/client_test.go
@@ -1,7 +1,7 @@
 package resttest_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -16,7 +16,7 @@ func TestNewClient(t *testing.T) {
 	cnt := int64(0)
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/foo?q=1", r.URL.String())
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, `{"foo":"bar"}`, string(b))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))

--- a/resttest/server_test.go
+++ b/resttest/server_test.go
@@ -3,7 +3,6 @@ package resttest_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -38,7 +37,7 @@ func assertRoundTrip(t *testing.T, baseURL string, expectation httpmock.Expectat
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	require.NoError(t, err)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 
@@ -161,7 +160,7 @@ func TestServerMock_ServeHTTP_error(t *testing.T) {
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	require.NoError(t, err)
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 
@@ -176,7 +175,7 @@ func TestServerMock_ServeHTTP_error(t *testing.T) {
 	resp, err = http.DefaultTransport.RoundTrip(req)
 	require.NoError(t, err)
 
-	respBody, err = ioutil.ReadAll(resp.Body)
+	respBody, err = io.ReadAll(resp.Body)
 	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 
@@ -191,7 +190,7 @@ func TestServerMock_ServeHTTP_error(t *testing.T) {
 	resp, err = http.DefaultTransport.RoundTrip(req)
 	require.NoError(t, err)
 
-	respBody, err = ioutil.ReadAll(resp.Body)
+	respBody, err = io.ReadAll(resp.Body)
 	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 
@@ -206,7 +205,7 @@ func TestServerMock_ServeHTTP_error(t *testing.T) {
 	resp, err = http.DefaultTransport.RoundTrip(req)
 	require.NoError(t, err)
 
-	respBody, err = ioutil.ReadAll(resp.Body)
+	respBody, err = io.ReadAll(resp.Body)
 	require.NoError(t, resp.Body.Close())
 	require.NoError(t, err)
 
@@ -250,7 +249,7 @@ func TestServerMock_ServeHTTP_concurrency(t *testing.T) {
 			resp, err := http.DefaultTransport.RoundTrip(req)
 			require.NoError(t, err)
 
-			respBody, err := ioutil.ReadAll(resp.Body)
+			respBody, err := io.ReadAll(resp.Body)
 			require.NoError(t, resp.Body.Close())
 			require.NoError(t, err)
 
@@ -301,7 +300,7 @@ func TestServerMock_vars(t *testing.T) {
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	require.NoError(t, err)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	require.NoError(t, resp.Body.Close())
@@ -340,7 +339,7 @@ func TestServerMock_ExpectAsync(t *testing.T) {
 		resp, err := http.DefaultTransport.RoundTrip(req)
 		require.NoError(t, err)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 
 		require.NoError(t, resp.Body.Close())
@@ -357,7 +356,7 @@ func TestServerMock_ExpectAsync(t *testing.T) {
 			resp, err := http.DefaultTransport.RoundTrip(req)
 			require.NoError(t, err)
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
 			require.NoError(t, resp.Body.Close())
@@ -371,7 +370,7 @@ func TestServerMock_ExpectAsync(t *testing.T) {
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	require.NoError(t, err)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	require.NoError(t, resp.Body.Close())

--- a/trait.go
+++ b/trait.go
@@ -22,7 +22,7 @@ type HandlerTrait struct {
 
 	// MakeErrResp overrides error response builder instead of default Err,
 	// returned values are HTTP status code and error structure to be marshaled.
-	MakeErrResp func(ctx context.Context, err error) (int, interface{})
+	MakeErrResp func(ctx context.Context, err error) (int, any)
 
 	// ReqMapping controls request decoding into use case input.
 	// Optional, if not set field tags are used as mapping.
@@ -51,7 +51,7 @@ func (h *HandlerTrait) RequestMapping() RequestMapping {
 }
 
 // OutputHasNoContent indicates if output does not seem to have any content body to render in response.
-func OutputHasNoContent(output interface{}) bool {
+func OutputHasNoContent(output any) bool {
 	if output == nil {
 		return true
 	}

--- a/validator.go
+++ b/validator.go
@@ -5,7 +5,7 @@ import "encoding/json"
 // Validator validates a map of decoded data.
 type Validator interface {
 	// ValidateData validates decoded request/response data and returns error in case of invalid data.
-	ValidateData(in ParamIn, namedData map[string]interface{}) error
+	ValidateData(in ParamIn, namedData map[string]any) error
 
 	// ValidateJSONBody validates JSON encoded body and returns error in case of invalid data.
 	ValidateJSONBody(jsonBody []byte) error
@@ -15,10 +15,10 @@ type Validator interface {
 }
 
 // ValidatorFunc implements Validator with a func.
-type ValidatorFunc func(in ParamIn, namedData map[string]interface{}) error
+type ValidatorFunc func(in ParamIn, namedData map[string]any) error
 
 // ValidateData implements Validator.
-func (v ValidatorFunc) ValidateData(in ParamIn, namedData map[string]interface{}) error {
+func (v ValidatorFunc) ValidateData(in ParamIn, namedData map[string]any) error {
 	return v(in, namedData)
 }
 
@@ -29,14 +29,14 @@ func (v ValidatorFunc) HasConstraints(_ ParamIn) bool {
 
 // ValidateJSONBody implements Validator.
 func (v ValidatorFunc) ValidateJSONBody(body []byte) error {
-	return v(ParamInBody, map[string]interface{}{"body": json.RawMessage(body)})
+	return v(ParamInBody, map[string]any{"body": json.RawMessage(body)})
 }
 
 // RequestJSONSchemaProvider provides request JSON Schemas.
 type RequestJSONSchemaProvider interface {
 	ProvideRequestJSONSchemas(
 		method string,
-		input interface{},
+		input any,
 		mapping RequestMapping,
 		validator JSONSchemaValidator,
 	) error
@@ -47,7 +47,7 @@ type ResponseJSONSchemaProvider interface {
 	ProvideResponseJSONSchemas(
 		statusCode int,
 		contentType string,
-		output interface{},
+		output any,
 		headerMapping map[string]string,
 		validator JSONSchemaValidator,
 	) error
@@ -63,7 +63,7 @@ type JSONSchemaValidator interface {
 
 // RequestValidatorFactory creates request validator for particular structured Go input value.
 type RequestValidatorFactory interface {
-	MakeRequestValidator(method string, input interface{}, mapping RequestMapping) Validator
+	MakeRequestValidator(method string, input any, mapping RequestMapping) Validator
 }
 
 // ResponseValidatorFactory creates response validator for particular structured Go output value.
@@ -71,7 +71,7 @@ type ResponseValidatorFactory interface {
 	MakeResponseValidator(
 		statusCode int,
 		contentType string,
-		output interface{},
+		output any,
 		headerMapping map[string]string,
 	) Validator
 }
@@ -87,8 +87,8 @@ func (re ValidationErrors) Error() string {
 }
 
 // Fields returns request errors by field location and name.
-func (re ValidationErrors) Fields() map[string]interface{} {
-	res := make(map[string]interface{}, len(re))
+func (re ValidationErrors) Fields() map[string]any {
+	res := make(map[string]any, len(re))
 
 	for k, v := range re {
 		res[k] = v

--- a/web/example_test.go
+++ b/web/example_test.go
@@ -21,7 +21,7 @@ type album struct {
 }
 
 func postAlbums() usecase.Interactor {
-	u := usecase.NewIOI(new(album), new(album), func(ctx context.Context, input, output interface{}) error {
+	u := usecase.NewIOI(new(album), new(album), func(ctx context.Context, input, output any) error {
 		log.Println("Creating album")
 
 		return nil
@@ -54,6 +54,7 @@ func ExampleDefaultService() {
 
 	log.Println("Starting service at http://localhost:8080")
 
+	//#nosec:G114
 	if err := http.ListenAndServe("localhost:8080", service); err != nil {
 		log.Fatal(err)
 	}

--- a/web/service_test.go
+++ b/web/service_test.go
@@ -3,9 +3,9 @@ package web_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +22,7 @@ type albumID struct {
 }
 
 func albumByID() usecase.Interactor {
-	u := usecase.NewIOI(new(albumID), new(album), func(ctx context.Context, input, output interface{}) error {
+	u := usecase.NewIOI(new(albumID), new(album), func(ctx context.Context, input, output any) error {
 		return nil
 	})
 	u.SetTags("Album")
@@ -67,7 +67,7 @@ func TestDefaultService(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rw.Code)
 	assertjson.EqualMarshal(t, rw.Body.Bytes(), service.OpenAPI)
 
-	expected, err := ioutil.ReadFile("_testdata/openapi.json")
+	expected, err := os.ReadFile("_testdata/openapi.json")
 	require.NoError(t, err)
 	assertjson.EqualMarshal(t, expected, service.OpenAPI)
 


### PR DESCRIPTION
So this PR is really two things (sorry):

1. renaming all `interface{}` -> `any` and `ioutil` deprecations (lots of files changes)
2. `Usecase` interactor hooks (`nethttp/handler.go` and associated test file)

My original intention was to just do the Usecase hooks, but the linter got the best of me :/

Anyways.... I have a need for running hooks after input is processed/validated but before the usecase is run (and the same for after the usecase is run, but before the output is validated).
It's a slice of function hooks, that are called before and after `useCase.Interact()` is called at `nethttp/handler.go:135`.