### PR TITLE
Implement support for multiple HTTP success statuses

### DIFF
--- a/openapi/collector.go
+++ b/openapi/collector.go
@@ -149,8 +149,7 @@ func (c *Collector) setupOutput(oc *openapi3.OperationContext, u usecase.Interac
 	if outputWithStatus, ok := oc.Output.(rest.OutputWithHTTPStatus); ok {
 		for _, status := range outputWithStatus.ExpectedHTTPStatuses() {
 			oc.HTTPStatus = status
-			err := c.Reflector().SetupResponse(*oc)
-			if err != nil {
+			if err := c.Reflector().SetupResponse(*oc); err != nil {
 				return err
 			}
 		}

--- a/openapi/collector.go
+++ b/openapi/collector.go
@@ -142,17 +142,26 @@ func (c *Collector) setupOutput(oc *openapi3.OperationContext, u usecase.Interac
 		noContent = true
 	}
 
-	if oc.HTTPStatus == 0 {
-		oc.HTTPStatus = status
-	}
-
 	if !noContent && oc.RespContentType == "" {
 		oc.RespContentType = c.DefaultSuccessResponseContentType
 	}
 
-	err := c.Reflector().SetupResponse(*oc)
-	if err != nil {
-		return err
+	if outputWithStatus, ok := oc.Output.(rest.OutputWithHTTPStatus); ok {
+		for _, status := range outputWithStatus.ExpectedHTTPStatuses() {
+			oc.HTTPStatus = status
+			err := c.Reflector().SetupResponse(*oc)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		if oc.HTTPStatus == 0 {
+			oc.HTTPStatus = status
+		}
+		err := c.Reflector().SetupResponse(*oc)
+		if err != nil {
+			return err
+		}
 	}
 
 	if oc.HTTPMethod == http.MethodHead {

--- a/openapi/collector_test.go
+++ b/openapi/collector_test.go
@@ -325,15 +325,15 @@ func TestCollector_Collect_CombineErrors(t *testing.T) {
 }
 
 // Output that implements OutputWithHTTPStatus interface.
-type outputWithHttpStatuses struct {
+type outputWithHTTPStatuses struct {
 	Number int `json:"number"`
 }
 
-func (outputWithHttpStatuses) HTTPStatus() int {
+func (outputWithHTTPStatuses) HTTPStatus() int {
 	return http.StatusCreated
 }
 
-func (outputWithHttpStatuses) ExpectedHTTPStatuses() []int {
+func (outputWithHTTPStatuses) ExpectedHTTPStatuses() []int {
 	return []int{http.StatusCreated, http.StatusOK}
 }
 
@@ -343,7 +343,7 @@ func TestCollector_Collect_multipleHttpStatuses(t *testing.T) {
 	u.SetTitle("Title")
 	u.SetName("name")
 	u.Input = new(struct{})
-	u.Output = new(outputWithHttpStatuses)
+	u.Output = new(outputWithHTTPStatuses)
 
 	require.NoError(t, c.Collect(http.MethodPost, "/foo", u, rest.HandlerTrait{
 		ReqValidator: &jsonschema.Validator{},
@@ -366,7 +366,7 @@ func TestCollector_Collect_multipleHttpStatuses(t *testing.T) {
 				"content": {
 				  "application/json": {
 					"schema": {
-					  "$ref": "#/components/schemas/OpenapiTestOutputWithHttpStatuses"
+					  "$ref": "#/components/schemas/OpenapiTestOutputWithHTTPStatuses"
 					}
 				  }
 				}
@@ -376,7 +376,7 @@ func TestCollector_Collect_multipleHttpStatuses(t *testing.T) {
 				"content": {
 				  "application/json": {
 					"schema": {
-					  "$ref": "#/components/schemas/OpenapiTestOutputWithHttpStatuses"
+					  "$ref": "#/components/schemas/OpenapiTestOutputWithHTTPStatuses"
 					}
 				  }
 				}
@@ -387,7 +387,7 @@ func TestCollector_Collect_multipleHttpStatuses(t *testing.T) {
 	  },
 	  "components": {
 		"schemas": {
-		  "OpenapiTestOutputWithHttpStatuses": {
+		  "OpenapiTestOutputWithHTTPStatuses": {
 			"type": "object",
 			"properties": {
 			  "number": {

--- a/response.go
+++ b/response.go
@@ -11,3 +11,9 @@ type ETagged interface {
 type JSONWriterTo interface {
 	JSONWriteTo(w io.Writer) (int, error)
 }
+
+// OutputWithHTTPStatus exposes HTTP status code(s) for output.
+type OutputWithHTTPStatus interface {
+	HTTPStatus() int
+	ExpectedHTTPStatuses() []int
+}

--- a/response/encoder.go
+++ b/response/encoder.go
@@ -191,10 +191,14 @@ func (h *Encoder) SetupOutput(output interface{}, ht *rest.HandlerTrait) {
 		return
 	}
 
-	if h.skipRendering && !h.outputWithWriter {
-		ht.SuccessStatus = http.StatusNoContent
+	if outputWithStatus, ok := output.(rest.OutputWithHTTPStatus); ok {
+		ht.SuccessStatus = outputWithStatus.HTTPStatus()
 	} else {
-		ht.SuccessStatus = http.StatusOK
+		if h.skipRendering && !h.outputWithWriter {
+			ht.SuccessStatus = http.StatusNoContent
+		} else {
+			ht.SuccessStatus = http.StatusOK
+		}
 	}
 }
 

--- a/response/encoder_test.go
+++ b/response/encoder_test.go
@@ -205,22 +205,22 @@ func TestEncoder_SetupOutput_nonPtr(t *testing.T) {
 }
 
 // Output that implements OutputWithHTTPStatus interface.
-type outputWithHttpStatuses struct {
+type outputWithHTTPStatuses struct {
 	Number int `json:"number"`
 }
 
-func (outputWithHttpStatuses) HTTPStatus() int {
+func (outputWithHTTPStatuses) HTTPStatus() int {
 	return http.StatusCreated
 }
 
-func (outputWithHttpStatuses) ExpectedHTTPStatuses() []int {
+func (outputWithHTTPStatuses) ExpectedHTTPStatuses() []int {
 	return []int{http.StatusCreated, http.StatusOK}
 }
 
 func TestEncoder_SetupOutput_httpStatus(t *testing.T) {
 	e := response.Encoder{}
 	ht := rest.HandlerTrait{}
-	e.SetupOutput(outputWithHttpStatuses{}, &ht)
+	e.SetupOutput(outputWithHTTPStatuses{}, &ht)
 
 	r, err := http.NewRequest(http.MethodPost, "/", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
When `OutputWithHTTPStatus` is implemented on the output port, `HTTPStatus()` defines the successful HTTP status of a given operation, and `ExpectedHTTPStatuses()` defines all expected HTTP statuses for API documentation purposes.

See #153 for the discussion about this feature.