### PR TITLE
Fix: Setting the HTTP status during the Encoder setup is insufficient

### DIFF
--- a/response/encoder.go
+++ b/response/encoder.go
@@ -191,14 +191,16 @@ func (h *Encoder) SetupOutput(output interface{}, ht *rest.HandlerTrait) {
 		return
 	}
 
+	ht.SuccessStatus = h.successStatus(output)
+}
+
+func (h *Encoder) successStatus(output interface{}) int {
 	if outputWithStatus, ok := output.(rest.OutputWithHTTPStatus); ok {
-		ht.SuccessStatus = outputWithStatus.HTTPStatus()
+		return outputWithStatus.HTTPStatus()
+	} else if h.skipRendering && !h.outputWithWriter {
+		return http.StatusNoContent
 	} else {
-		if h.skipRendering && !h.outputWithWriter {
-			ht.SuccessStatus = http.StatusNoContent
-		} else {
-			ht.SuccessStatus = http.StatusOK
-		}
+		return http.StatusOK
 	}
 }
 
@@ -353,7 +355,7 @@ func (h *Encoder) WriteSuccessfulResponse(
 	}
 
 	if ht.SuccessStatus == 0 {
-		ht.SuccessStatus = http.StatusOK
+		ht.SuccessStatus = h.successStatus(output)
 	}
 
 	if skipRendering {

--- a/response/encoder_test.go
+++ b/response/encoder_test.go
@@ -221,12 +221,18 @@ func TestEncoder_SetupOutput_httpStatus(t *testing.T) {
 	e := response.Encoder{}
 	ht := rest.HandlerTrait{}
 	e.SetupOutput(outputWithHTTPStatuses{}, &ht)
+	assert.Equal(t, http.StatusCreated, ht.SuccessStatus)
+}
+
+func TestEncoder_Writer_httpStatus(t *testing.T) {
+	e := response.Encoder{}
+	e.SetupOutput(outputWithHTTPStatuses{}, &rest.HandlerTrait{})
 
 	r, err := http.NewRequest(http.MethodPost, "/", nil)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
-	output := e.MakeOutput(w, ht)
-	e.WriteSuccessfulResponse(w, r, output, ht)
+	output := e.MakeOutput(w, rest.HandlerTrait{})
+	e.WriteSuccessfulResponse(w, r, output, rest.HandlerTrait{})
 	assert.Equal(t, http.StatusCreated, w.Code)
 }


### PR DESCRIPTION
Sorry, my previous PR had a bug 😅 

Setting the HTTP status during the Encoder setup is insufficient: we must also set it when actually encoding the output (as concrete output values might have different statuses).