### PR TITLE
Only application/json should be allowed by default

### DIFF
--- a/request/jsonbody.go
+++ b/request/jsonbody.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/swaggest/rest"
@@ -71,7 +72,7 @@ func checkJSONBodyContentType(contentType string, tolerateFormData bool) (ret bo
 		return false, nil
 	}
 
-	if len(contentType) < 16 || contentType[0:16] != "application/json" { // allow 'application/json;charset=UTF-8'
+	if strings.ToLower(contentType) != "application/json" {
 		if tolerateFormData && (contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data") {
 			return true, nil
 		}


### PR DESCRIPTION
According to https://github.com/swaggest/rest/issues/113 valid JSON Content-Type is application/json.

According to https://datatracker.ietf.org/doc/html/rfc2045#section-5.1 Content-Type values should be compared in case-insensitive manner.

Fixes: https://github.com/swaggest/rest/issues/134
Author-Change-Id: IB#1131224