### PR TITLE
fix: allow 'application/json;charset=UTF-8'

### DIFF
--- a/request/jsonbody.go
+++ b/request/jsonbody.go
@@ -72,7 +72,7 @@ func checkJSONBodyContentType(contentType string, tolerateFormData bool) (ret bo
 		return false, nil
 	}
 
-	if strings.ToLower(contentType) != "application/json" {
+	if !strings.Contains(strings.ToLower(contentType), "application/json") {
 		if tolerateFormData && (contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data") {
 			return true, nil
 		}

--- a/request/jsonbody_test.go
+++ b/request/jsonbody_test.go
@@ -117,3 +117,16 @@ func Test_decodeJSONBody_tolerateFormData(t *testing.T) {
 	assert.Empty(t, i.CustomerID)
 	assert.Empty(t, i.Type)
 }
+
+func Test_decodeJSONBody_charset(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "any", bytes.NewBufferString(`{"amount": 123}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json;charset=utf-8")
+
+	type Input struct {
+		Amount int `json:"amount" formData:"amount"`
+	}
+	i := Input{}
+
+	assert.NoError(t, decodeJSONBody(readJSON, false)(req, &i, nil))
+}


### PR DESCRIPTION
This is a regression - charset was allowed in versions prior to v0.2.50