### PR TITLE
Validate JSON body before unmarshalling into input type

### DIFF
--- a/request/jsonbody_test.go
+++ b/request/jsonbody_test.go
@@ -81,7 +81,7 @@ func Test_decodeJSONBody_unmarshalFailed(t *testing.T) {
 	var i []int
 
 	err = decodeJSONBody(readJSON, false)(req, &i, nil)
-	assert.EqualError(t, err, "failed to decode json: json: cannot unmarshal number into Go value of type []int")
+	assert.EqualError(t, err, "json: cannot unmarshal number into Go value of type []int")
 }
 
 func Test_decodeJSONBody_validateFailed(t *testing.T) {


### PR DESCRIPTION
Fix for #202 

Instead of first reading the JSON into the input object, perform validation to return appropriate error messages in case 
of trying to parse an invalid type mapping, e.g. `int` to `string`. 

Originally you would get `failed to decode json: json: cannot unmarshall...` error and now it returns more context instead, for example:

```Go
{
  "status": "INVALID_ARGUMENT",
  "error": "invalid argument: validation failed",
  "context": {
    "body": [
      "#/name: expected string, but got number"
    ]
  }
}
```