### PR TITLE
Fix " http: superfluous response.WriteHeader call from ..." on embedded resp setter

### DIFF
--- a/response/encoder.go
+++ b/response/encoder.go
@@ -403,7 +403,7 @@ func (h *Encoder) WriteSuccessfulResponse(
 	}
 
 	if skipRendering {
-		if ht.SuccessStatus != http.StatusOK {
+		if !h.outputWithWriter && !h.dynamicSetter && ht.SuccessStatus != http.StatusOK {
 			w.WriteHeader(ht.SuccessStatus)
 		}
 


### PR DESCRIPTION
```
2024/10/06 12:39:59 http: superfluous response.WriteHeader call from github.com/swaggest/rest/response.(*Encoder).WriteSuccessfulResponse (encoder.go:407)
```

This warning happens when `out *response.EmbeddedSetter` is used for an HTML output.