### PR TITLE
Add a method to mount HEAD/GET at once

### DIFF
--- a/_examples/advanced-generic-openapi31/_testdata/openapi.json
+++ b/_examples/advanced-generic-openapi31/_testdata/openapi.json
@@ -254,6 +254,18 @@
      }
     },
     "x-forbid-unknown-path":true,"x-forbid-unknown-query":true
+   },
+   "head":{
+    "tags":["Response"],"summary":"Request With HTML Response",
+    "description":"Request with templated HTML response.",
+    "operationId":"_examples/advanced-generic-openapi31.htmlResponse2",
+    "parameters":[
+     {"name":"filter","in":"query","schema":{"type":"string"}},
+     {"name":"id","in":"path","required":true,"schema":{"type":"integer"}},
+     {"name":"X-Header","in":"header","schema":{"type":"boolean"}}
+    ],
+    "responses":{"200":{"description":"OK","headers":{"X-Anti-Header":{"style":"simple","schema":{"type":"boolean"}}}}},
+    "x-forbid-unknown-path":true,"x-forbid-unknown-query":true
    }
   },
   "/json-body-manual/{in-path}":{

--- a/_examples/advanced-generic-openapi31/gzip_pass_through.go
+++ b/_examples/advanced-generic-openapi31/gzip_pass_through.go
@@ -81,7 +81,8 @@ func directGzip() usecase.Interactor {
 
 		// Imitating an internal read operation on data in container.
 		if in.CountItems {
-			_ = len((*out).gzipPassThroughStruct().Text)
+			cnt := len((*out).gzipPassThroughStruct().Text)
+			println("items: ", cnt)
 		}
 
 		return nil

--- a/_examples/advanced-generic-openapi31/html_response_test.go
+++ b/_examples/advanced-generic-openapi31/html_response_test.go
@@ -42,6 +42,26 @@ func Test_htmlResponse(t *testing.T) {
 </html>`, string(body), string(body))
 }
 
+func Test_htmlResponse_HEAD(t *testing.T) {
+	r := NewRouter()
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Head(srv.URL + "/html-response/123?filter=feel")
+	require.NoError(t, err)
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, "true", resp.Header.Get("X-Anti-Header"))
+	assert.Equal(t, "text/html", resp.Header.Get("Content-Type"))
+	assert.Empty(t, body)
+}
+
 // Benchmark_htmlResponse-12    	   89209	     12348 ns/op	         0.3801 50%:ms	         1.119 90%:ms	         2.553 99%:ms	         3.877 99.9%:ms	       370.0 B:rcvd/op	       108.0 B:sent/op	     80973 rps	    8279 B/op	     144 allocs/op.
 func Benchmark_htmlResponse(b *testing.B) {
 	r := NewRouter()

--- a/_examples/advanced-generic-openapi31/output_headers_test.go
+++ b/_examples/advanced-generic-openapi31/output_headers_test.go
@@ -58,6 +58,33 @@ func Test_outputHeaders(t *testing.T) {
 	assertjson.Equal(t, []byte(`{"inBody":"def"}`), body)
 }
 
+func Test_outputHeaders_HEAD(t *testing.T) {
+	r := NewRouter()
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodHead, srv.URL+"/output-headers", nil)
+	require.NoError(t, err)
+
+	req.Header.Set("x-FoO", "40")
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, "abc", resp.Header.Get("X-Header"))
+	assert.Equal(t, "20", resp.Header.Get("X-Foo"))
+	assert.Equal(t, "10", resp.Header.Get("X-Omit-Empty"))
+	assert.Equal(t, []string{"coo=123; HttpOnly"}, resp.Header.Values("Set-Cookie"))
+	assert.Empty(t, body)
+}
+
 func Test_outputHeaders_invalidReq(t *testing.T) {
 	r := NewRouter()
 

--- a/_examples/advanced-generic-openapi31/router.go
+++ b/_examples/advanced-generic-openapi31/router.go
@@ -173,7 +173,7 @@ func NewRouter() http.Handler {
 			return nil
 		}))
 
-	s.Get("/html-response/{id}", htmlResponse(), nethttp.SuccessfulResponseContentType("text/html"))
+	s.HeadGet("/html-response/{id}", htmlResponse(), nethttp.SuccessfulResponseContentType("text/html"))
 
 	s.Get("/output-headers", outputHeaders())
 	s.Head("/output-headers", outputHeaders())

--- a/_examples/advanced/_testdata/openapi.json
+++ b/_examples/advanced/_testdata/openapi.json
@@ -76,6 +76,25 @@
           }
         },
         "x-forbid-unknown-query":true
+      },
+      "head":{
+        "summary":"Dynamic Request Schema",
+        "description":"This use case demonstrates documentation of types that are only known at runtime.",
+        "operationId":"_examples/advanced.dynamicSchema2",
+        "parameters":[
+          {"name":"bar","in":"query","schema":{"type":"string"}},
+          {"name":"type","in":"query","schema":{"type":"string"}},
+          {"name":"foo","in":"header","schema":{"enum":["123","456","789"],"type":"integer"}}
+        ],
+        "responses":{
+          "200":{
+            "description":"OK",
+            "headers":{"foo":{"style":"simple","schema":{"enum":["123","456","789"],"type":"integer"}}}
+          },
+          "400":{"description":"Bad Request"},"409":{"description":"Conflict"},
+          "412":{"description":"Precondition Failed"}
+        },
+        "x-forbid-unknown-query":true
       }
     },
     "/error-response":{
@@ -121,6 +140,22 @@
             "description":"Precondition Failed",
             "content":{"application/problem+json":{"schema":{"$ref":"#/components/schemas/AdvancedCustomErr"}}}
           }
+        },
+        "x-forbid-unknown-query":true
+      },
+      "head":{
+        "summary":"Declare Expected Errors",
+        "description":"This use case demonstrates documentation of expected errors.",
+        "operationId":"_examples/advanced.errorResponse2",
+        "parameters":[
+          {
+            "name":"type","in":"query","required":true,
+            "schema":{"enum":["ok","invalid_argument","conflict"],"type":"string"}
+          }
+        ],
+        "responses":{
+          "200":{"description":"OK"},"400":{"description":"Bad Request"},"409":{"description":"Conflict"},
+          "412":{"description":"Precondition Failed"}
         },
         "x-forbid-unknown-query":true
       }
@@ -357,6 +392,35 @@
           }
         },
         "x-forbid-unknown-cookie":true,"x-forbid-unknown-path":true,"x-forbid-unknown-query":true
+      },
+      "head":{
+        "summary":"Request With JSON Query Parameter",
+        "description":"Request with JSON body and query/header/path params, response with JSON body and data from request.",
+        "operationId":"_examples/advanced.jsonParam2",
+        "parameters":[
+          {
+            "name":"in_query","in":"query","description":"Simple scalar value in query.",
+            "schema":{"type":"integer","description":"Simple scalar value in query."}
+          },
+          {
+            "name":"identity","in":"query","description":"JSON value in query",
+            "content":{"application/json":{"schema":{"$ref":"#/components/schemas/AdvancedJSONPayload"}}}
+          },
+          {
+            "name":"in-path","in":"path","description":"Simple scalar value in path","required":true,
+            "schema":{"type":"string","description":"Simple scalar value in path"}
+          },
+          {
+            "name":"in_cookie","in":"cookie","description":"UUID in cookie.",
+            "schema":{"$ref":"#/components/schemas/UuidUUID"}
+          },
+          {
+            "name":"X-Header","in":"header","description":"Simple scalar value in header.",
+            "schema":{"type":"string","description":"Simple scalar value in header."}
+          }
+        ],
+        "responses":{"200":{"description":"OK"}},"x-forbid-unknown-cookie":true,"x-forbid-unknown-path":true,
+        "x-forbid-unknown-query":true
       }
     },
     "/json-slice-body":{
@@ -441,6 +505,21 @@
             "content":{"application/problem+json":{"schema":{"$ref":"#/components/schemas/AdvancedCustomErr"}}}
           }
         }
+      },
+      "head":{
+        "summary":"Output With Stream Writer","description":"Output with stream writer.",
+        "responses":{
+          "200":{
+            "description":"OK",
+            "headers":{
+              "X-Header":{
+                "style":"simple","description":"Sample response header.",
+                "schema":{"type":"string","description":"Sample response header."}
+              }
+            }
+          },
+          "500":{"description":"Internal Server Error"}
+        }
       }
     },
     "/output-headers":{
@@ -502,6 +581,16 @@
           }
         },
         "x-forbid-unknown-query":true
+      },
+      "head":{
+        "summary":"Request With Object As Query Parameter","operationId":"_examples/advanced.queryObject2",
+        "parameters":[
+          {
+            "name":"in_query","in":"query","description":"Object value in query.","style":"deepObject","explode":true,
+            "schema":{"type":"object","additionalProperties":{"type":"number"},"description":"Object value in query."}
+          }
+        ],
+        "responses":{"200":{"description":"OK"}},"x-forbid-unknown-query":true
       }
     },
     "/req-resp-mapping":{

--- a/_examples/advanced/gzip_pass_through_test.go
+++ b/_examples/advanced/gzip_pass_through_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,6 +28,29 @@ func Test_directGzip(t *testing.T) {
 	assert.Equal(t, "gzip", rw.Header().Get("Content-Encoding"))
 	assert.Equal(t, "abc", rw.Header().Get("X-Header"))
 	assert.Less(t, len(rw.Body.Bytes()), 500)
+}
+
+func Test_directGzip_HEAD(t *testing.T) {
+	srv := httptest.NewServer(NewRouter())
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodHead, srv.URL+"/gzip-pass-through", nil)
+	require.NoError(t, err)
+
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "330epditz19z", resp.Header.Get("Etag"))
+	assert.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+	assert.Equal(t, "abc", resp.Header.Get("X-Header"))
+	assert.Empty(t, body)
 }
 
 func Test_noDirectGzip(t *testing.T) {

--- a/_examples/advanced/router.go
+++ b/_examples/advanced/router.go
@@ -57,6 +57,7 @@ func NewRouter() http.Handler {
 	jsr.AddTypeMapping(uuid.UUID{}, uuidDef)
 
 	s.OpenAPICollector.CombineErrors = "anyOf"
+	s.AddHeadToGet = true
 
 	s.Wrap(
 		// Response validator setup.
@@ -125,7 +126,6 @@ func NewRouter() http.Handler {
 		}))
 
 	s.Get("/output-headers", outputHeaders())
-	s.Head("/output-headers", outputHeaders())
 	s.Get("/output-csv-writer", outputCSVWriter(),
 		nethttp.SuccessfulResponseContentType("text/csv; charset=utf-8"))
 
@@ -146,7 +146,6 @@ func NewRouter() http.Handler {
 	// Type mapping is necessary to pass interface as structure into documentation.
 	jsr.AddTypeMapping(new(gzipPassThroughOutput), new(gzipPassThroughStruct))
 	s.Get("/gzip-pass-through", directGzip())
-	s.Head("/gzip-pass-through", directGzip())
 
 	s.Get("/error-response", errorResponse())
 	s.Get("/dynamic-schema", dynamicSchema())

--- a/web/service.go
+++ b/web/service.go
@@ -2,7 +2,6 @@
 package web
 
 import (
-	"io"
 	"net/http"
 	"strings"
 
@@ -137,6 +136,7 @@ func (s *Service) Delete(pattern string, uc usecase.Interactor, options ...func(
 func (s *Service) Get(pattern string, uc usecase.Interactor, options ...func(h *nethttp.Handler)) {
 	if s.AddHeadToGet {
 		s.HeadGet(pattern, uc, options...)
+
 		return
 	}
 
@@ -154,22 +154,8 @@ func (s *Service) Head(pattern string, uc usecase.Interactor, options ...func(h 
 // Response body is automatically ignored.
 func (s *Service) HeadGet(pattern string, uc usecase.Interactor, options ...func(h *nethttp.Handler)) {
 	h := nethttp.NewHandler(uc, options...)
-
-	s.Method(http.MethodHead, pattern, nethttp.WrapHandler(h, func(handler http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w = struct {
-				http.ResponseWriter
-				io.Writer
-			}{
-				ResponseWriter: w,
-				Writer:         io.Discard,
-			}
-
-			handler.ServeHTTP(w, r)
-		})
-	}))
-
 	s.Method(http.MethodGet, pattern, h)
+	s.Method(http.MethodHead, pattern, h)
 }
 
 // Options adds the route `pattern` that matches a OPTIONS http method to invoke use case interactor.

--- a/web/service.go
+++ b/web/service.go
@@ -138,6 +138,14 @@ func (s *Service) Head(pattern string, uc usecase.Interactor, options ...func(h 
 	s.Method(http.MethodHead, pattern, nethttp.NewHandler(uc, options...))
 }
 
+// HeadGet adds the route `pattern` that matches a HEAD/GET http method to invoke use case interactor.
+//
+// Response body is automatically ignored.
+func (s *Service) HeadGet(pattern string, uc usecase.Interactor, options ...func(h *nethttp.Handler)) {
+	s.Method(http.MethodHead, pattern, nethttp.NewHandler(uc, options...))
+	s.Method(http.MethodGet, pattern, nethttp.NewHandler(uc, options...))
+}
+
 // Options adds the route `pattern` that matches a OPTIONS http method to invoke use case interactor.
 func (s *Service) Options(pattern string, uc usecase.Interactor, options ...func(h *nethttp.Handler)) {
 	s.Method(http.MethodOptions, pattern, nethttp.NewHandler(uc, options...))


### PR DESCRIPTION
This pull request introduces a new method to the `Service` struct in the `web/service.go` file to handle both HEAD and GET HTTP methods simultaneously. This change aims to simplify the routing configuration for endpoints that should respond to both methods with the same use case interactor.

Key change:

* [`web/service.go`](diffhunk://#diff-8f4f140743c7606db25ecb21e5a845edd0ddf03e5b21e61cb747cd0f53a0341eR141-R148): Added the `HeadGet` method to the `Service` struct, which registers a route pattern for both HEAD and GET HTTP methods, invoking the same use case interactor.