### PR TITLE
feat: add support for special characters in path

### DIFF
--- a/chirouter/example_test.go
+++ b/chirouter/example_test.go
@@ -45,7 +45,8 @@ func ExamplePathToURLValues() {
 
 	// Serving example URL.
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodPost, "/foo/abc/bar/123?query1=321",
+
+	req, _ := http.NewRequest(http.MethodPost, `/foo/a%2Fbc/bar/123?query1=321`,
 		bytes.NewBufferString("formData1=true&formData2=def"))
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -53,5 +54,5 @@ func ExamplePathToURLValues() {
 
 	router.ServeHTTP(w, req)
 	// Output:
-	// {Query1:321 Path1:abc Path2:123 Header1:1.23 FormData1:true FormData2:def}
+	// {Query1:321 Path1:a/bc Path2:123 Header1:1.23 FormData1:true FormData2:def}
 }

--- a/chirouter/path_decoder.go
+++ b/chirouter/path_decoder.go
@@ -9,7 +9,7 @@ import (
 )
 
 // PathToURLValues is a decoder function for parameters in path.
-func PathToURLValues(r *http.Request) (url.Values, error) { //nolint:unparam // Matches request.DecoderFactory.SetDecoderFunc.
+func PathToURLValues(r *http.Request) (url.Values, error) {
 	if routeCtx := chi.RouteContext(r.Context()); routeCtx != nil {
 		params := make(url.Values, len(routeCtx.URLParams.Keys))
 

--- a/chirouter/path_decoder.go
+++ b/chirouter/path_decoder.go
@@ -1,6 +1,7 @@
 package chirouter
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -14,6 +15,10 @@ func PathToURLValues(r *http.Request) (url.Values, error) { //nolint:unparam // 
 
 		for i, key := range routeCtx.URLParams.Keys {
 			value := routeCtx.URLParams.Values[i]
+			value, err := url.PathUnescape(value)
+			if err != nil {
+				return nil, fmt.Errorf("PathToUrlValues: %w", err)
+			}
 			params[key] = []string{value}
 		}
 

--- a/chirouter/path_decoder.go
+++ b/chirouter/path_decoder.go
@@ -15,6 +15,7 @@ func PathToURLValues(r *http.Request) (url.Values, error) { //nolint:unparam // 
 
 		for i, key := range routeCtx.URLParams.Keys {
 			value := routeCtx.URLParams.Values[i]
+
 			value, err := url.PathUnescape(value)
 			if err != nil {
 				return nil, fmt.Errorf("unescaping path: %w", err)

--- a/chirouter/path_decoder.go
+++ b/chirouter/path_decoder.go
@@ -17,7 +17,7 @@ func PathToURLValues(r *http.Request) (url.Values, error) { //nolint:unparam // 
 			value := routeCtx.URLParams.Values[i]
 			value, err := url.PathUnescape(value)
 			if err != nil {
-				return nil, fmt.Errorf("PathToUrlValues: %w", err)
+				return nil, fmt.Errorf("unescaping path: %w", err)
 			}
 			params[key] = []string{value}
 		}

--- a/chirouter/path_decoder.go
+++ b/chirouter/path_decoder.go
@@ -20,6 +20,7 @@ func PathToURLValues(r *http.Request) (url.Values, error) { //nolint:unparam // 
 			if err != nil {
 				return nil, fmt.Errorf("unescaping path: %w", err)
 			}
+
 			params[key] = []string{value}
 		}
 


### PR DESCRIPTION
This change adds support for parsing URL encoded characters, ensuring regex matches down the pipeline can be executed against the unescaped, raw value, matching the contents of the generated swagger documentation.