### PR TITLE
Support for JSONSchema SkipUnsupportedProperties

### DIFF
--- a/request/factory.go
+++ b/request/factory.go
@@ -290,6 +290,9 @@ func (df *DecoderFactory) makeDefaultDecoder(input interface{}, m *decoder) {
 
 			s, err := df.JSONSchemaReflector.Reflect(vi)
 			if err != nil {
+				if err == jsonschema.ErrSkipProperty {
+					return
+				}
 				panic(err.Error())
 			}
 


### PR DESCRIPTION
i have an edgecase, where i need to inline include a really large and upstream dependent go structure from another package into the Input/Output usecase structure definition
That structure has all the needed json tags, yet, it has the `context.CancelFunc 'json:"-"'` field, which causes panic at the reflection step due to obviously unsupported type

jsonschema has the SkipUnsupportedProperties option for that case, which can be enabled by modifying default decoder options, but it not supported by the rest itself
https://github.com/swaggest/jsonschema-go/blob/a12059cd34136a1006ac484eacff11e4c167d071/context.go#L243
